### PR TITLE
getSymbols.R - missing call to unlink temp files

### DIFF
--- a/R/getDividends.R
+++ b/R/getDividends.R
@@ -19,13 +19,13 @@ function(Symbol,from='1970-01-01',to=Sys.Date(),env=parent.frame(),src='yahoo',
   to.d <- as.numeric(strsplit(as.character(to), "-", )[[1]][3])
 
   tmp <- tempfile()
+  on.exit(unlink(tmp))
   download.file(paste(yahoo.URL,Symbol.name, "&a=", 
             from.m, "&b=", sprintf("%.2d", from.d), "&c=", from.y, 
             "&d=", to.m, "&e=", sprintf("%.2d", to.d), "&f=", 
             to.y, "&g=v&ignore=.csv", 
             sep = ""), destfile = tmp, quiet = !verbose)
   fr <- read.csv(tmp)
-  unlink(tmp)
   fr <- xts(fr[,2],as.Date(fr[,1]))
   if(is.xts(Symbol)) {
     if(auto.update) {

--- a/R/getFinancials.R
+++ b/R/getFinancials.R
@@ -9,6 +9,7 @@ getFin <- function(Symbol, env=parent.frame(), src="google", auto.assign=TRUE, .
   Symbol.name <- Symbol
   google.fin <- "http://finance.google.com/finance?fstype=ii&q=" 
   tmp <- tempfile()
+  on.exit(unlink(tmp))
   download.file(paste(google.fin,Symbol,sep=""),quiet=TRUE,destfile=tmp)
   Symbol <- readLines(tmp, warn=FALSE)
 
@@ -59,6 +60,7 @@ getFin <- function(Symbol, env=parent.frame(), src="google", auto.assign=TRUE, .
 `.getFin` <-
 function(Symbol, env = parent.frame(), src='google', auto.assign = TRUE, ...) {
   tmp <- tempfile()
+  on.exit(unlink(tmp))
   download.file(paste('http://finance.google.com/finance?fstype=ii&q=',Symbol,sep=''),
                 quiet=TRUE,destfile=tmp)
   Symbol.name <- Symbol

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -15,6 +15,7 @@ function(Symbols,src='yahoo',what, ...) {
 `getQuote.yahoo` <-
 function(Symbols,what=standardQuote(),...) {
   tmp <- tempfile()
+  on.exit(unlink(tmp))
   if(length(Symbols) > 1 && is.character(Symbols))
     Symbols <- paste(Symbols,collapse=";")
   length.of.symbols <- length(unlist(strsplit(Symbols, ";")))
@@ -49,7 +50,6 @@ function(Symbols,what=standardQuote(),...) {
                 "&f=",QF,sep=""),
                 destfile=tmp,quiet=TRUE)
   sq <- read.csv(file=tmp,sep=',',stringsAsFactors=FALSE,header=FALSE)
-  unlink(tmp)
   Qposix <- strptime(paste(sq[,1],sq[,2]),format='%m/%d/%Y %H:%M')
   Symbols <- unlist(strsplit(Symbols,'\\+'))
   df <- data.frame(Qposix,sq[,3:NCOL(sq)])

--- a/R/getSplits.R
+++ b/R/getSplits.R
@@ -21,13 +21,13 @@ function(Symbol,from='1970-01-01',to=Sys.Date(),env=parent.frame(),src='yahoo',
   to.d <- as.numeric(strsplit(as.character(to), "-", )[[1]][3])
 
   tmp <- tempfile()
+  on.exit(unlink(tmp))
   download.file(paste(yahoo.URL,Symbol.name, "&a=", 
             from.m, "&b=", sprintf("%.2d", from.d), "&c=", from.y, 
             "&d=", to.m, "&e=", sprintf("%.2d", to.d), "&f=", 
             to.y, "&g=v&y=0&z=30000", 
             sep = ""), destfile = tmp, quiet = !verbose)
   fr <- read.table(tmp, skip=1, fill=TRUE, as.is=TRUE, sep=",")
-  unlink(tmp)
   fr <- fr[fr$V1=="SPLIT",]
 
   if(NROW(fr)==0) {

--- a/R/getSymbols.R
+++ b/R/getSymbols.R
@@ -235,7 +235,10 @@ function(Symbols,env,return.class='xts',index.class="Date",
      if(!hasArg(verbose)) verbose <- FALSE
      if(!hasArg(auto.assign)) auto.assign <- TRUE
      yahoo.URL <- "http://ichart.finance.yahoo.com/table.csv?"
+     tmp <- tempfile()
+     on.exit(unlink(tmp))
      for(i in 1:length(Symbols)) {
+       truncate(tmp)
        return.class <- getSymbolLookup()[[Symbols[[i]]]]$return.class
        return.class <- ifelse(is.null(return.class),default.return.class,
                               return.class)
@@ -254,10 +257,8 @@ function(Symbols,env,return.class='xts',index.class="Date",
        Symbols.name <- getSymbolLookup()[[Symbols[[i]]]]$name
        Symbols.name <- ifelse(is.null(Symbols.name),Symbols[[i]],Symbols.name)
        if(verbose) cat("downloading ",Symbols.name,".....\n\n")
-       tmp <- tempfile()
-       tryCatch(
-       {
-         download.file(paste(yahoo.URL,
+       
+       download.file(paste(yahoo.URL,
                   "s=",Symbols.name,
                   "&a=",from.m,
                   "&b=",sprintf('%.2d',from.d),
@@ -269,12 +270,7 @@ function(Symbols,env,return.class='xts',index.class="Date",
                   "&z=",Symbols.name,"&x=.csv",
                   sep=''),destfile=tmp,quiet=!verbose)
          fr <- read.csv(tmp)
-       }, 
-       finally = 
-       {
-         unlink(tmp)
-       })
-       
+
        if(verbose) cat("done.\n")
        fr <- xts(as.matrix(fr[,-1]),
                  as.Date(fr[,1]),
@@ -377,11 +373,11 @@ function(Symbols,env,return.class='xts',index.class="Date",
             
             page <- 1
             totalrows <- c()
+            tmp <- tempfile()
+            on.exit(unlink(tmp))
             while (TRUE) {
-                tmp <- tempfile()
-                tryCatch(
-                {
-                  download.file(paste(yahoo.URL,
+                truncate(tmp)
+                download.file(paste(yahoo.URL,
                                     "?code=",Symbols.name,
                                     "&sm=",from.m,
                                     "&sd=",sprintf('%.2d',from.d),
@@ -393,13 +389,8 @@ function(Symbols,env,return.class='xts',index.class="Date",
                                     "&p=",page,
                                     sep=''),destfile=tmp,quiet=!verbose)
                 
-                  fdoc <- XML::htmlParse(tmp)
-                }, 
-                finally = 
-                {
-                  unlink(tmp)
-                })
-                
+                fdoc <- XML::htmlParse(tmp)
+
                 rows <- XML::xpathApply(fdoc, "//table[@class='boardFin yjSt marB6']//tr")
                 if (length(rows) == 1) break
                 
@@ -490,14 +481,15 @@ function(Symbols,env,return.class='xts',
      to.y <- as.numeric(strsplit(as.character(to),'-',)[[1]][1])
      to.m <- as.numeric(strsplit(as.character(to),'-',)[[1]][2])
      to.d <- as.numeric(strsplit(as.character(to),'-',)[[1]][3])
+     
+     tmp <- tempfile()
+     on.exit(unlink(tmp))
      for(i in 1:length(Symbols)) {
+       truncate(tmp)
        Symbols.name <- getSymbolLookup()[[Symbols[[i]]]]$name
        Symbols.name <- ifelse(is.null(Symbols.name),Symbols[[i]],Symbols.name)
        if(verbose) cat("downloading ",Symbols.name,".....\n\n")
-       tmp <- tempfile()
-       tryCatch(
-       {
-         download.file(paste(google.URL,
+       download.file(paste(google.URL,
                            "q=",Symbols.name,
                            "&startdate=",month.abb[from.m],
                            "+",sprintf('%.2d',from.d),
@@ -507,13 +499,8 @@ function(Symbols,env,return.class='xts',
                            ",+",to.y,
                            "&output=csv",
                            sep=''),destfile=tmp,quiet=!verbose)
-         fr <- read.csv(tmp)
-       }, 
-       finally = 
-       {
-         unlink(tmp)
-       })
-       
+       fr <- read.csv(tmp)
+
        if(verbose) cat("done.\n")
        fr <- fr[nrow(fr):1,] #google data is backwards
        if(fix.google.bug) {
@@ -682,22 +669,19 @@ function(Symbols,env,return.class='xts',
      if(!hasArg(verbose)) verbose <- FALSE
      if(!hasArg(auto.assign)) auto.assign <- TRUE
      FRED.URL <- "http://research.stlouisfed.org/fred2/series"
+     
+     tmp <- tempfile()
+     on.exit(unlink(tmp))
      for(i in 1:length(Symbols)) {
+       truncate(tmp)
        if(verbose) cat("downloading ",Symbols[[i]],".....\n\n")
-       tmp <- tempfile()
-       tryCatch(
-       {
-         download.file(paste(FRED.URL,"/",
+       download.file(paste(FRED.URL,"/",
                             Symbols[[i]],"/",
                             "downloaddata/",
                             Symbols[[i]],".csv",sep=""),
                             destfile=tmp,quiet=!verbose)
-         fr <- read.csv(tmp,na.string=".")
-       }, 
-       finally = 
-       {
-         unlink(tmp)
-       })
+       fr <- read.csv(tmp,na.string=".")
+       
        if(verbose) cat("done.\n")
        fr <- xts(as.matrix(fr[,-1]),
                  as.Date(fr[,1],origin='1970-01-01'),
@@ -1064,7 +1048,10 @@ function(Symbols,env,return.class='xts',
      daySpans <- c(7, 30, 60, 90, 180, 364, 728, 1820)
      dateStr <- c("d7", "d30", "d60", "d90", "d180", "y1", "y2", "y5")
 
+     tmp <- tempfile()
+     on.exit(unlink(tmp))
      for(i in 1:length(Symbols)) {
+       truncate(tmp)
        return.class <- getSymbolLookup()[[Symbols[[i]]]]$return.class
        return.class <- ifelse(is.null(return.class),default.return.class,
                               return.class)
@@ -1084,7 +1071,7 @@ function(Symbols,env,return.class='xts',
        }
 
        if(verbose) cat("downloading ",Symbols.name,".....")
-       tmp <- tempfile()
+       
        # Request minimum data from server to fulfill user's request
        dateDiff <- difftime(to, from, units="days")
        dateLoc <- which(daySpans >= dateDiff)
@@ -1105,15 +1092,9 @@ function(Symbols,env,return.class='xts',
          "&base_currency_1=&base_currency_2=&base_currency_3=&base_currency_4=&download=csv",
          sep="")
          
-       tryCatch(
-       {
-         download.file(oanda.URL, destfile=tmp, quiet=!verbose)
-         fr <- read.csv(tmp, skip=4, as.is=TRUE, header=TRUE)
-       }, 
-       finally = 
-       {
-         unlink(tmp)
-       })
+       download.file(oanda.URL, destfile=tmp, quiet=!verbose)
+       fr <- read.csv(tmp, skip=4, as.is=TRUE, header=TRUE)
+       
        fr[,1L] <- as.Date(fr[,1L], origin="1970-01-01")
        fr <- na.omit(fr[,1:2])    # remove period mean/min/max from end of file
        if(is.character(fr[,2L]))  # remove thousands seperator and convert


### PR DESCRIPTION
Fixing "too many open files" bug in any case of http error (previously it missed unlink of temp file). (For example 404, when the equity does not exists on the specified source)