### PR TITLE
Fixes #57: Automatic detection of OHLC vs OHLCVA

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,5 @@ src
 WISHLIST
 #R/replot.R
 #R/chart_Series.R
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+quantmod.Rproj
+.Rproj.user
+.Rhistory
+.RData
+src/*.o
+src/*.so
+src/*.dll

--- a/R/getSymbols.R
+++ b/R/getSymbols.R
@@ -397,8 +397,11 @@ function(Symbols,env,return.class='xts',index.class="Date",
             
             # Available columns
             cols <- c('Open','High','Low','Close','Volume','Adjusted')
-            if (grepl(".O$", Symbols.name)) cols <- cols[-(5:6)]
             
+            firstrow <- totalrows[[1]]
+            cells <- XML::getNodeSet(firstrow, "th")
+            if (length(cells) == 5) cols <- cols[-(5:6)]
+
             # Process from the start, for easier stocksplit management
             totalrows <- rev(totalrows)
             mat <- matrix(0, ncol=length(cols) + 1, nrow=0, byrow=TRUE)


### PR DESCRIPTION
Determines whether it is OHLC or OHLCVA data (including volume and
adjusted closes) by checking the number of columns in the first row with
the th's.