### PR TITLE
Add handling of mutual fund data from yahooj

### DIFF
--- a/R/getSymbols.R
+++ b/R/getSymbols.R
@@ -450,7 +450,7 @@ function(Symbols,env,return.class='xts',index.class="Date",
             
             colnames(fr) <- paste(symname, cols, sep='.')
             
-            fr <- quantmod:::convert.time.series(fr=fr,return.class=return.class)
+            fr <- convert.time.series(fr=fr,return.class=return.class)
             if(is.xts(fr))
                 indexClass(fr) <- index.class
             

--- a/R/getSymbols.R
+++ b/R/getSymbols.R
@@ -408,27 +408,39 @@ function(Symbols,env,return.class='xts',index.class="Date",
             for(row in totalrows) {
                 cells <- XML::getNodeSet(row, "td")
                 
-                # 2 cells means it is a stocksplit row
-                # So extract stocksplit data and recalculate the matrix we have so far
-                if (length(cells) == 2 & length(cols) == 6 & nrow(mat) > 1) {
-                    ss.data <- as.numeric(na.omit(as.numeric(unlist(strsplit(XML::xmlValue(cells[[2]]), "[^0-9]+")))))
-                    factor <- ss.data[2] / ss.data[1]
+                if (nchar(Symbols.name) == 8 && length(cells) == 3) {
+                    # For mutual fund from yahooj, only unit price is able to acquired
+                    # Length of ticker code must be 8.
+                    unit.price <- as.numeric(gsub(",", "", XML::xmlValue(cells[[2]])))
                     
-                    mat <- rbind(t(apply(mat[-nrow(mat),], 1, function(x) {
-                        x * c(1, rep(1/factor, 4), factor, 1)
-                    })), mat[nrow(mat),])
-                }
-                
-                if (length(cells) != length(cols) + 1) next
-                
-                # Parse the Japanese date format using UTF characters
-                # \u5e74 = "year"
-                # \u6708 = "month"
-                # \u65e5 = "day"
-                date <- as.Date(XML::xmlValue(cells[[1]]), format="%Y\u5e74%m\u6708%d\u65e5")
-                entry <- c(date)
-                for(n in 2:length(cells)) {
-                    entry <- cbind(entry, as.numeric(gsub(",", "", XML::xmlValue(cells[[n]]))))
+                    date <- as.Date(XML::xmlValue(cells[[1]]), format="%Y\u5e74%m\u6708%d\u65e5")
+                    # Fill other candle values by unit.price like the format of yahoo.us
+                    # Fill NA for "adjusted" due to lack of dividend information
+                    entry <- c(date, unit.price, unit.price, unit.price, unit.price, 0, NA)
+                    
+                } else {
+                    # 2 cells means it is a stocksplit row
+                    # So extract stocksplit data and recalculate the matrix we have so far
+                    if (length(cells) == 2 & length(cols) == 6 & nrow(mat) > 1) {
+                        ss.data <- as.numeric(na.omit(as.numeric(unlist(strsplit(XML::xmlValue(cells[[2]]), "[^0-9]+")))))
+                        factor <- ss.data[2] / ss.data[1]
+                        
+                        mat <- rbind(t(apply(mat[-nrow(mat),], 1, function(x) {
+                            x * c(1, rep(1/factor, 4), factor, 1)
+                        })), mat[nrow(mat),])
+                    }
+                    
+                    if (length(cells) != length(cols) + 1) next
+                    
+                    # Parse the Japanese date format using UTF characters
+                    # \u5e74 = "year"
+                    # \u6708 = "month"
+                    # \u65e5 = "day"
+                    date <- as.Date(XML::xmlValue(cells[[1]]), format="%Y\u5e74%m\u6708%d\u65e5")
+                    entry <- c(date)
+                    for(n in 2:length(cells)) {
+                        entry <- cbind(entry, as.numeric(gsub(",", "", XML::xmlValue(cells[[n]]))))
+                    }
                 }
                 
                 mat <- rbind(mat, entry)
@@ -438,7 +450,7 @@ function(Symbols,env,return.class='xts',index.class="Date",
             
             colnames(fr) <- paste(symname, cols, sep='.')
             
-            fr <- convert.time.series(fr=fr,return.class=return.class)
+            fr <- quantmod:::convert.time.series(fr=fr,return.class=return.class)
             if(is.xts(fr))
                 indexClass(fr) <- index.class
             


### PR DESCRIPTION
I'm {quantmod} user for a long time and I thank for your great developments.
* What I needed was to get Japanese mutual fund's unit price to create a new portfolio.
* This commit allows `getSymbols.yahooj()` to get mutual fund data from yahooj.
* I'd appreciate if you could run a below code in your environment and feedback whether it works well.
    `getSymbols.yahooj("0131510B", from = "2015-10-01")`

```
> sessionInfo()
R version 3.2.3 (2015-12-10)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 7 x64 (build 7601) Service Pack 1

locale:
[1] LC_COLLATE=Japanese_Japan.932  LC_CTYPE=Japanese_Japan.932   
[3] LC_MONETARY=Japanese_Japan.932 LC_NUMERIC=C                  
[5] LC_TIME=Japanese_Japan.932    
```
