### PR TITLE
Updated getSymbols.MySQL SELECT statement to include dbname variable …

### DIFF
--- a/R/getSymbols.R
+++ b/R/getSymbols.R
@@ -599,7 +599,7 @@ function(Symbols,env,return.class='xts',
                                db.fields=c('date','o','h','l','c','v','a'),
                                field.names = NULL,
                                user=NULL,password=NULL,dbname=NULL,host='localhost',port=3306,
-                               ...) {
+                               from=NULL, to=NULL, ...) {
      importDefaults("getSymbols.MySQL")
      this.env <- environment()
      for(var in names(list(...))) {
@@ -631,7 +631,13 @@ function(Symbols,env,return.class='xts',
             if(verbose) {
                 cat(paste('Loading ',Symbols[[i]],paste(rep('.',10-nchar(Symbols[[i]])),collapse=''),sep=''))
             }
-            query <- paste("SELECT ",paste(db.fields,collapse=',')," FROM ",Symbols[[i]]," ORDER BY date")
+          
+            if (!is.null(from) & !is.null(to)) {
+              query <- paste("SELECT ", paste(db.fields, collapse = ","), " FROM ", paste("`", Symbols[[i]], "`", sep = ""), " WHERE date >= '", from, "' AND date <= '", to, "' ORDER BY date")
+            } else {
+              query <- paste("SELECT ", paste(db.fields, collapse = ","), " FROM ", paste("`", Symbols[[i]], "`", sep = ""), " ORDER BY date")
+            }
+            
             rs <- DBI::dbSendQuery(con, query)
             fr <- DBI::fetch(rs, n=-1)
             #fr <- data.frame(fr[,-1],row.names=fr[,1])


### PR DESCRIPTION
…when specifying table. Resolves issue with tables named after MySQL operators (eg. ADD). Triggered by an issue working with Australian Stock Exchange data that contains the ADD symbol.

EDIT 2016-07-19: This pull contains two changes-
1. Added 'from' and 'to' options to getSymbols.MySQL for subsetting by date in database call. 
2. Added backticks to getSymbols.MySQL SELECT statement, fixes error retrieving symbols with same name as SQL operators.

Branch commit history has been squashed/rebased for merge.
