### PR TITLE
Refactor chartSeries() function to be a wrapper for chart_Series() function

### DIFF
--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -402,7 +402,7 @@ function(x,
       sub.index <- index(do.call(subsetvec[1],list(x,subset.n)))
       xsubset <- which(index(x) %in% sub.index)
     } else xsubset <- which(index(x) %in% index(x[subset]))  
-  } else xsubset <- ""
+  } else xsubset <- 1:NROW(x)
 
   xdata <- x
   x <- x[xsubset]

--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -473,6 +473,9 @@ function(x,
   if(is.null(name)) name <- as.character(match.call()$x)
   cs <- chart_Series(x = xdata, name = name, type = chart[1],
                      subset = xsubset, yaxis.left = FALSE, ...)
+  # set xlim to reserve space
+  xlim <- cs$get_xlim()
+  cs$set_xlim(c(xlim[1]-xlim[2]*0.04,xlim[2]+xlim[2]*0.04))
   # remove x-axis grid line
   cs$Env$actions[[1]] <- NULL
 
@@ -508,7 +511,7 @@ function(x,
   #cs$Env$theme$minor.tick
   #cs$Env$theme$main.color
   #cs$Env$theme$sub.col
-  cs$Env$theme$fill <- theme$fill
+  cs$Env$theme$fill <- theme$area
   
   cs$Env$color.vol <- color.vol
   cs$Env$multi.col <- multi.col
@@ -546,8 +549,7 @@ function(x,
   cs$Env$actions[[1]] <- exp
   
   # add border
-  exp.border <- expression(rect(xlim[1], get_ylim()[[2]][1], xlim[2], get_ylim()[[2]][2],col=theme$fill),
-                           segments(xlim[1], y_grid_lines(get_ylim()[[2]]), xlim[2], 
+  exp.border <- expression(segments(xlim[1], y_grid_lines(get_ylim()[[2]]), xlim[2], 
                                     y_grid_lines(get_ylim()[[2]]), col = theme$grid, lwd = grid.ticks.lwd, 
                                     lty = grid.ticks.lty), text(xlim[2] + xstep * 2/3, y_grid_lines(get_ylim()[[2]]), 
                                                                 noquote(format(y_grid_lines(get_ylim()[[2]]), justify = "right")), 
@@ -559,6 +561,11 @@ function(x,
   exp.border <- structure(exp.border, env = cs$Env)
   cs$Env$actions[[4]] <- exp.border
 
+  # add inbox color
+  exp.area <- expression(rect(xlim[1], get_ylim()[[2]][1], xlim[2], get_ylim()[[2]][2],col=theme$fill))
+  cs$set_frame(-2)
+  cs$add(exp.area, env=cs$Env, expr=TRUE)
+  
   # add legend
   text.exp <- expression(
     Closes <- Cl(xdata),

--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -579,7 +579,11 @@ function(x,
   cs$add(text.exp, env=cs$Env, expr=TRUE)
   
   # handle TA="addVo()" as we would interactively FIXME: allow TA=NULL to work
-  if(!show.vol) TA <- TA[-grep("addVo()", TA)]
+  TA <- unlist(strsplit(TA, TAsep))
+  if(!show.vol) {
+    which.vo <- match("addVo()", TA)
+    if(!is.na(which.vo)) TA <- TA[-which.vo]
+  }
   if(!is.null(TA) && length(TA) > 0) {
     TA <- parse(text=TA, srcfile=NULL)
     for(ta in seq_along(TA)) {

--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -540,7 +540,7 @@ function(x,
   
   # change minor ticks to be downward
   exp <- expression(if (NROW(xdata[xsubset]) < 400) { 
-    axis(1, at = xycoords$x, labels = FALSE, col = theme$grid2, 
+    axis(1, at = xycoords$x[1:NROW(xsubset)], labels = FALSE, col = theme$grid2, 
          col.axis = theme$grid2, tcl = -0.4)
   })
   exp <- structure(exp, frame = 1)

--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -533,6 +533,17 @@ function(x,
   cs$Env$theme$bbands$col$upper <- theme$BBands.col
   cs$Env$theme$bbands$col$lower <- theme$BBands.col
 
+  # add legend
+  text.exp <- expression(
+    Closes <- Cl(xdata),
+    lc <- xts:::legend.coords("topleft", xlim, get_ylim()[[2]]),
+    legend(x = lc$x, y = lc$y,
+           legend = paste("Last", last(Closes)), 
+           text.col = theme$up.col, 
+           bty='n', 
+           y.intersp=0.95))
+  cs$set_frame(2)
+  cs$add(text.exp, env=cs$Env, expr=TRUE)
   if(plot) # draw the chart
     cs
 } #}}}

--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -568,10 +568,10 @@ function(x,
   
   # add legend
   text.exp <- expression(
-    Closes <- Cl(xdata),
+    Closes <- Cl(xdata[xsubset]),
     lc <- xts:::legend.coords("topleft", xlim, get_ylim()[[2]]),
     legend(x = lc$x, y = lc$y,
-           legend = paste("Last", last(Closes)), 
+           legend = paste("Last", sprintf("%.3f", last(Closes))), 
            text.col = theme$up.col, 
            bty='n', 
            y.intersp=0.95))

--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -276,7 +276,10 @@ function(x,subset = NULL,
                                 fill="#F7F7F7",
                                 Expiry='#C9C9C9',
                                 BBands.col='#666666',BBands.fill="#F7F7F7",
-                                BBands=list(col='#666666',fill='#F7F7F7'),
+                                BBands=list(col=list(upper='#666666',
+                                                     lower='#666666',
+                                                     fill='#F7F7F7',
+                                                     ma='#D5D5D5')),
                                 theme.name='white.mono'
                                 ),
                       'black'=
@@ -294,7 +297,10 @@ function(x,subset = NULL,
                                 fill="#282828",
                                 Expiry='#383838',
                                 BBands.col='red',BBands.fill="#282828",
-                                BBands=list(col='red',fill='#282828'),
+                                BBands=list(col=list(upper='red',
+                                                     lower='red',
+                                                     fill='#282828',
+                                                     ma='#D5D5D5')),
                                 theme.name='black'
                                 ),
                       'black.mono'=
@@ -310,7 +316,10 @@ function(x,subset = NULL,
                                 main.col="#999999",sub.col="#999999",
                                 fill="#777777",
                                 Expiry='#383838',
-                                BBands=list(col='#DDDDDD',fill='#777777'),
+                                BBands=list(col=list(upper='#DDDDDD',
+                                                     lower='#DDDDDD',
+                                                     fill='#777777',
+                                                     ma='#D5D5D5')),
                                 BBands.col='#DDDDDD',BBands.fill="#777777",
                                 theme.name='black.mono'
                                 ),
@@ -328,7 +337,10 @@ function(x,subset = NULL,
                                 fill="#F5F5F5",
                                 Expiry='#C9C9C9',
                                 BBands.col='orange',BBands.fill='#F5F5DF',
-                                BBands=list(col='orange',fill='#F5F5DF'),
+                                BBands=list(col=list(upper='orange',
+                                                     lower='orange',
+                                                     fill='#F5F5DF',
+                                                     ma='#D5D5D5')),
                                 theme.name='beige'
                                 ),
                        'wsj'= 
@@ -534,9 +546,17 @@ function(x,
   }
 
   cs$Env$length <- NROW(x)
-  cs$Env$theme$bbands$col$fill <- theme$BBands.fill
-  cs$Env$theme$bbands$col$upper <- theme$BBands.col
-  cs$Env$theme$bbands$col$lower <- theme$BBands.col
+  cs$Env$theme$BBands$col$fill <- theme$BBands$col$fill
+  cs$Env$theme$BBands$col$upper <- theme$BBands$col$upper
+  cs$Env$theme$BBands$col$lower <- theme$BBands$col$lower
+  cs$Env$theme$BBands$col$ma <- theme$BBands$col$ma
+  
+  # allow custom settings to TAs color
+  # use chartTheme() to enter
+  which.TA <- grep("add", names(theme))
+  names(theme)[which.TA] <- gsub("^add", "", names(theme)[which.TA])
+  cs$Env$theme <- append(cs$Env$theme, theme[which.TA])
+  
   
   # change minor ticks to be downward
   exp <- expression(if (NROW(xdata[xsubset]) < 400) { 

--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -594,6 +594,16 @@ function(x,
       }
     }
   }
+  # Pass chart.layout settings
+  cs$Env$chart.layout <- chart.layout
+  if(!inherits(layout, "chart.layout")) {
+    cl <- chart.layout(length(cs$Env$ylim)-1)
+  } else
+    cl <- layout
+  # since xts::plot.xts is applied, chartSeries should now be layout free
+  # layout(cl$mat, cl$width, cl$height, respect=FALSE)
+  cs$Env$mar <- cl$par.list[[3]]$mar
+  
   assign(".xts_chob", cs, xts:::.plotxtsEnv)
   if(plot) # draw the chart
     cs

--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -473,6 +473,8 @@ function(x,
   if(is.null(name)) name <- as.character(match.call()$x)
   cs <- chart_Series(x = xdata, name = name, type = chart[1],
                      subset = xsubset, yaxis.left = FALSE, ...)
+  # remove x-axis grid line
+  cs$Env$actions[[1]] <- NULL
 
   if(is.OHLC(x)) {
     cs$Env$ylim[[2]] <- structure(c(min(Lo(x),na.rm=TRUE),max(Hi(x),na.rm=TRUE)), fixed = TRUE)
@@ -502,11 +504,11 @@ function(x,
   cs$Env$theme$fg <- theme$fg.col
   cs$Env$theme$labels <- theme$major.tick
   # deprecated arguments(?
-  #cs$Env$theme$border
+  cs$Env$theme$border <- theme$border
   #cs$Env$theme$minor.tick
   #cs$Env$theme$main.color
   #cs$Env$theme$sub.col
-  #cs$Env$theme$fill
+  cs$Env$theme$fill <- theme$fill
   
   cs$Env$color.vol <- color.vol
   cs$Env$multi.col <- multi.col
@@ -541,7 +543,21 @@ function(x,
   exp <- structure(exp, frame = 1)
   exp <- structure(exp, clip = TRUE)
   exp <- structure(exp, env = cs$Env)
-  cs$Env$actions[[2]] <- exp
+  cs$Env$actions[[1]] <- exp
+  
+  # add border
+  exp.border <- expression(rect(xlim[1], get_ylim()[[2]][1], xlim[2], get_ylim()[[2]][2],col=theme$fill),
+                           segments(xlim[1], y_grid_lines(get_ylim()[[2]]), xlim[2], 
+                                    y_grid_lines(get_ylim()[[2]]), col = theme$grid, lwd = grid.ticks.lwd, 
+                                    lty = grid.ticks.lty), text(xlim[2] + xstep * 2/3, y_grid_lines(get_ylim()[[2]]), 
+                                                                noquote(format(y_grid_lines(get_ylim()[[2]]), justify = "right")), 
+                                                                col = theme$labels, srt = theme$srt, offset = 0, pos = 4, 
+                                                                cex = theme$cex.axis, xpd = TRUE),
+                           rect(xlim[1], get_ylim()[[2]][1], xlim[2], get_ylim()[[2]][2],border=theme$labels))
+  exp.border <- structure(exp.border, frame = 2)
+  exp.border <- structure(exp.border, clip = TRUE)
+  exp.border <- structure(exp.border, env = cs$Env)
+  cs$Env$actions[[4]] <- exp.border
 
   # add legend
   text.exp <- expression(

--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -577,6 +577,20 @@ function(x,
            y.intersp=0.95))
   cs$set_frame(2)
   cs$add(text.exp, env=cs$Env, expr=TRUE)
+  
+  # handle TA="addVo()" as we would interactively FIXME: allow TA=NULL to work
+  if(!show.vol) TA <- TA[-grep("addVo()", TA)]
+  if(!is.null(TA) && length(TA) > 0) {
+    TA <- parse(text=TA, srcfile=NULL)
+    for(ta in seq_along(TA)) {
+      if(length(TA[ta][[1]][-1]) > 0) {
+        cs <- eval(TA[ta])
+      } else {
+        cs <- eval(TA[ta])
+      }
+    }
+  }
+  assign(".xts_chob", cs, xts:::.plotxtsEnv)
   if(plot) # draw the chart
     cs
 } #}}}

--- a/R/chartSeries.R
+++ b/R/chartSeries.R
@@ -532,6 +532,16 @@ function(x,
   cs$Env$theme$bbands$col$fill <- theme$BBands.fill
   cs$Env$theme$bbands$col$upper <- theme$BBands.col
   cs$Env$theme$bbands$col$lower <- theme$BBands.col
+  
+  # change minor ticks to be downward
+  exp <- expression(if (NROW(xdata[xsubset]) < 400) { 
+    axis(1, at = xycoords$x, labels = FALSE, col = theme$grid2, 
+         col.axis = theme$grid2, tcl = -0.4)
+  })
+  exp <- structure(exp, frame = 1)
+  exp <- structure(exp, clip = TRUE)
+  exp <- structure(exp, env = cs$Env)
+  cs$Env$actions[[2]] <- exp
 
   # add legend
   text.exp <- expression(


### PR DESCRIPTION
chartSeries() function is now a wrapper for chart_Series() function so S4 method and objects, `chob` and `chobTA`, are deprecated. That means chartSeries.chob() function and chartTA() function are no longer available as well. Since chartSeries() has more detailed arguments than chart_Series(), mostly color settings, main changes are matching the parameters created by chartTheme() function with parameters of chart_theme() function that already exist in plot_object$Env$theme and passing those arguments to the plot object. Minor ticks setting of chartSeries() is different from its default setting in plot.xts() so the action is rewritten to make minor ticks downwards and space for both sides is reserved.
