### PR TITLE
Refactor reChart function to make plot_object settings changeable

### DIFF
--- a/R/reChart.R
+++ b/R/reChart.R
@@ -51,32 +51,6 @@ function (type = c("auto", "candlesticks", "matchsticks",
   if(!missing(name)) chob$Env$main <- name
   ########### end name ###########
 
-  ########### type ###########
-#  if(!missing(type)) {
-    chart.options <- c("auto","candlesticks","matchsticks","line","bars")
-    chart <- chart.options[pmatch(type,chart.options)]
-    if(chart[1]=="auto") {
-      chart <- ifelse(NROW(x[subset]) > 300,"matchsticks","candlesticks")
-    }
-    if(chart[1]=="candlesticks") {
-      spacing <- 3
-      width <- 3
-    } else
-    if(chart[1]=="matchsticks" || chart[1]=='line') {
-      spacing <- 1
-      width <- 1
-    } else
-    if(chart[1]=="bars") {
-      spacing <- 4
-      width <- 3
-      if(NROW(x[subset]) > 60) width <- 1
-    }
-#    chob@spacing <- spacing
-    chob$Env$theme$width <- width
-    chob$Env$range.bars.type <- chart[1]
-#  }
-  ########### end type ###########
-
   ########### subset ##########
   if(!missing(subset)) {
     if (!is.null(subset) & is.character(subset)) {
@@ -120,6 +94,32 @@ function (type = c("auto", "candlesticks", "matchsticks",
   }
   xsubset <- chob$Env$xsubset
   ########### end subset ##########
+  
+  ########### type ###########
+  #  if(!missing(type)) {
+  chart.options <- c("auto","candlesticks","matchsticks","line","bars")
+  chart <- chart.options[pmatch(type,chart.options)]
+  if(chart[1]=="auto") {
+    chart <- ifelse(NROW(x) > 300,"matchsticks","candlesticks")
+  }
+  if(chart[1]=="candlesticks") {
+    spacing <- 3
+    width <- 3
+  } else
+    if(chart[1]=="matchsticks" || chart[1]=='line') {
+      spacing <- 1
+      width <- 1
+    } else
+      if(chart[1]=="bars") {
+        spacing <- 4
+        width <- 3
+        if(NROW(x) > 60) width <- 1
+      }
+  #    chob@spacing <- spacing
+  chob$Env$theme$width <- width
+  chob$Env$range.bars.type <- chart[1]
+  #  }
+  ########### end type ###########
 
   if(!missing(major.ticks)) {
     chob$Env$bp <- axTicksByTime(chob$Env$xdata[chob$Env$xsubset],major.ticks)
@@ -163,9 +163,10 @@ function (type = c("auto", "candlesticks", "matchsticks",
       chob$Env$theme$grid2 <- theme$grid.col
     }
     
-    chob$Env$theme$bbands$col$fill <- theme$BBands.fill
-    chob$Env$theme$bbands$col$upper <- theme$BBands.col
-    chob$Env$theme$bbands$col$lower <- theme$BBands.col
+    chob$Env$theme$BBands$col$fill <- theme$BBands$col$fill
+    chob$Env$theme$BBands$col$upper <- theme$BBands$col$upper
+    chob$Env$theme$BBands$col$lower <- theme$BBands$col$lower
+    chob$Env$theme$BBands$col$ma <- theme$BBands$col$ma
   }
   ########### end chartTheme ##########
 

--- a/R/reChart.R
+++ b/R/reChart.R
@@ -52,11 +52,11 @@ function (type = c("auto", "candlesticks", "matchsticks",
   ########### end name ###########
 
   ########### type ###########
-  if(!missing(type)) {
+#  if(!missing(type)) {
     chart.options <- c("auto","candlesticks","matchsticks","line","bars")
     chart <- chart.options[pmatch(type,chart.options)]
     if(chart[1]=="auto") {
-      chart <- ifelse(NROW(x) > 300,"matchsticks","candlesticks")
+      chart <- ifelse(NROW(x[subset]) > 300,"matchsticks","candlesticks")
     }
     if(chart[1]=="candlesticks") {
       spacing <- 3
@@ -69,12 +69,12 @@ function (type = c("auto", "candlesticks", "matchsticks",
     if(chart[1]=="bars") {
       spacing <- 4
       width <- 3
-      if(NROW(x) > 60) width <- 1
+      if(NROW(x[subset]) > 60) width <- 1
     }
 #    chob@spacing <- spacing
     chob$Env$theme$width <- width
     chob$Env$range.bars.type <- chart[1]
-  }
+#  }
   ########### end type ###########
 
   ########### subset ##########

--- a/R/reChart.R
+++ b/R/reChart.R
@@ -7,8 +7,41 @@ function (type = c("auto", "candlesticks", "matchsticks",
     yrange=NULL,
     up.col, dn.col, color.vol = TRUE, multi.col = FALSE, ...) 
 {
+  # refactor xts:::chart.lines to make subset functionality work
+  chart.lines <- function (x, type = "l", lty = 1, lwd = 2, lend = 1, col = 1:10, 
+                           up.col = NULL, dn.col = NULL, legend.loc = NULL, ...) 
+  {
+    if (is.null(up.col)) 
+      up.col <- "green"
+    if (is.null(dn.col)) 
+      dn.col <- "red"
+    xx <- xts:::current.xts_chob()
+    switch(type, h = {
+      colors <- ifelse(x[, 1] < 0, dn.col, up.col)
+      lines(xx$Env$xycoords$x[match(index(x), index(xx$Env$xdata))], x[, 1], lwd = 2, col = colors, 
+            lend = lend, lty = 1, type = "h", ...)
+    }, p = , l = , b = , c = , o = , s = , S = , n = {
+      if (length(lty) < NCOL(x)) lty <- rep(lty, length.out = NCOL(x))
+      if (length(lwd) < NCOL(x)) lwd <- rep(lwd, length.out = NCOL(x))
+      if (length(col) < NCOL(x)) col <- rep(col, length.out = NCOL(x))
+      for (i in NCOL(x):1) {
+        lines(xx$Env$xycoords$x[match(index(x), index(xx$Env$xdata))], x[, i], type = type, lend = lend, 
+              col = col[i], lty = lty[i], lwd = lwd[i], ...)
+      }
+    }, {
+      warning(paste(type, "not recognized. Type must be one of\n                         'p', 'l', 'b, 'c', 'o', 'h', 's', 'S', 'n'.\n                         plot.xts supports the same types as plot.default,\n                         see ?plot for valid arguments for type"))
+    })
+    if (!is.null(legend.loc)) {
+      lc <- legend.coords(legend.loc, xx$Env$xlim, range(x, 
+                                                         na.rm = TRUE))
+      legend(x = lc$x, y = lc$y, legend = colnames(x), xjust = lc$xjust, 
+             yjust = lc$yjust, fill = col[1:NCOL(x)], bty = "n")
+    }
+  }
+  
+  
   chob <- current.chob()
-
+  chob$Env$chart.lines <- chart.lines
   #sys.TZ <- Sys.getenv('TZ')
   #Sys.setenv(TZ='GMT')
   #on.exit(Sys.setenv(TZ=sys.TZ))
@@ -74,7 +107,7 @@ function (type = c("auto", "candlesticks", "matchsticks",
             na.rm = TRUE)), fixed = TRUE)
       }   
       else chob$Env$ylim[[2]] <- structure(range(x[, 1], na.rm = TRUE), fixed = TRUE)
-      if(!is.null(yrange) && length(yrange)==2) chob$Env$ylim[[2]] <- structure(yrangea, fixed = TRUE)
+      if(!is.null(yrange) && length(yrange)==2) chob$Env$ylim[[2]] <- structure(yrange, fixed = TRUE)
     }
 
     chob$Env$xsubset <- xsubset
@@ -85,6 +118,7 @@ function (type = c("auto", "candlesticks", "matchsticks",
 #    chob$Env$x.labels <- names(chob$Env$bp)
     chob$Env$length <- NROW(x)
   }
+  xsubset <- chob$Env$xsubset
   ########### end subset ##########
 
   if(!missing(major.ticks)) {


### PR DESCRIPTION
reChart function is the base function called by `zoomChart()` and `zooom()`.
Since plot_object$subset didn't seem to work for plot.xts based object, special handling is provided to fix unequal length issue and make x-axis and y-axis value changeable. The issue occurs in `xts:::chart.lines()` function which calls `lines()` to draw original price series for x by plot_object$Env$xycoords$x and the subset series for y. So it throws error: "'x' and 'y' lengths differ." See issue joshuaulrich/xts#146 for more detailed information.
