### PR TITLE
Update zooom function to support refactored chartSeries function

### DIFF
--- a/R/zoomChart.R
+++ b/R/zoomChart.R
@@ -23,8 +23,8 @@ function (n = 1, eps = 2)
         }
         else {
             usr <- par("usr")
-            xdata <- get.chob()[[2]]@xdata
-            xsubset <- get.chob()[[2]]@xsubset
+            xdata <- current.chob()$Env$xdata
+            xsubset <- current.chob()$Env$xsubset
             sq <- floor(seq(usr[1], usr[2], 1))
             st <- which(floor(points$x[1]) == sq)/length(sq) * 
                 NROW(xdata[xsubset])
@@ -33,9 +33,10 @@ function (n = 1, eps = 2)
             sorted <- sort(c(st, en))
             st <- sorted[1]
             en <- sorted[2] * 1.05
-            zoomChart(paste(index(xdata[xsubset])[max(1, floor(st), 
-                na.rm = TRUE)], index(xdata[xsubset])[min(ceiling(en), 
-                NROW(xdata[xsubset]), na.rm = TRUE)], sep = "::"))
+            cs <- zoomChart(subset = paste(index(xdata[xsubset])[max(1, floor(st), 
+                    na.rm = TRUE)], index(xdata[xsubset])[min(ceiling(en), 
+                    NROW(xdata[xsubset]), na.rm = TRUE)], sep = "::"))
+            print(cs)
         }
     }
     cat("done\n")


### PR DESCRIPTION
Since S4 method used by chartSeries is deprecated, xdata and xsubset should
now be obtained from `.plotxtsEnv` environment. 
plot object needs to be returned by calling `return()` or being executed at the end 
of the code otherwise it will not be printed. To print both the plot object and 
"done" message, `print()` is used. But passing the plot object created by `zooom()` 
to an object is not supported.

```
data("sample_matrix")
x <- sample_matrix
chartSeries(x)
x.subset <- zooom()
x.subset
# NULL
```
