### PR TITLE
Yahoo getOptionChain scraper patch following site change.

### DIFF
--- a/R/getOptionChain.R
+++ b/R/getOptionChain.R
@@ -13,11 +13,6 @@ getOptionChain.yahoo <- function(Symbols, Exp, ...)
   library("XML")
   library("rjson")
   
-  millisToDate <- function(x)
-  {
-    return (as.Date(x / 86400000, origin = "1970-01-01"))
-  }
-  
   dateToMillis <- function(x)
   {
     as.numeric(x) * 86400000	/ 1000

--- a/R/getOptionChain.R
+++ b/R/getOptionChain.R
@@ -10,101 +10,98 @@ function(Symbols, Exp=NULL, src="yahoo", ...) {
 
 getOptionChain.yahoo <- function(Symbols, Exp, ...)
 {
-  if(!requireNamespace("XML", quietly=TRUE))
-    stop("package:",dQuote("XML"),"cannot be loaded.")
-
-  thParse <- function(x) {
-    if (length(XML::xmlChildren(x)) > 1) {
-      XML::xmlValue(x[["div"]][["div"]])
-    } else {
-      XML::xmlValue(x)
+  library("XML")
+  library("rjson")
+  
+  millisToDate <- function(x)
+  {
+    return (as.Date(x / 86400000, origin = "1970-01-01"))
+  }
+  
+  dateToMillis <- function(x)
+  {
+    as.numeric(x) * 86400000	/ 1000
+  }
+  
+  parse.expiry <- function(x) {
+    if (is.null(x))
+      return(NULL)
+    if (is.character(x))
+    {
+      x <- as.Date(x)
     }
+    if (inherits(x, "Date") || inherits(x, "POSIXt"))
+      return(dateToMillis(x))
+    return(NULL)
   }
-  NewToOld <- function(x, nm) {
-    if(is.null(x))
-      return(x)
-    # clean up colnames, in case there's weirdness in the HTML
-    x <- setNames(x, make.names(nm))
-    # set cleaned up colnames to current output colnames
-    d <- with(x, data.frame(Strike=strike, Last=last, Chg=change,
-      Bid=bid, Ask=ask, Vol=volume, OI=openinterest,
-      row.names=`contractname`, stringsAsFactors=FALSE))
-    # remove commas from the numeric data
-    d[] <- lapply(d, gsub, pattern=",", replacement="", fixed=TRUE)
-    d[] <- lapply(d, type.convert, as.is=TRUE)
-    d
-  }
-  cleanNames <- function(x) {
-    tolower(gsub("[[:space:]]", "", x))
-  }
-
-  # Don't check the expiry date if we're looping over dates we just scraped
-  checkExp <- !hasArg(".expiry.known") || !match.call(expand.dots=TRUE)$.expiry.known
-  # Construct URL
-  urlExp <- paste0("http://finance.yahoo.com/q/op?s=", Symbols[1])
-  # Add expiry date to URL
-  if(!checkExp)
-    urlExp <- paste0(urlExp, "&date=", Exp)
-
-  # Fetch data; ensure object is free'd on function exit
-  tbl <- XML::htmlParse(urlExp, isURL=TRUE)
-  on.exit(XML::free(tbl))
-
-  # xpaths to the data we're interested in
-  xpaths <- list()
-  xpaths$tables <- "//table[contains(@class, 'quote-table')]"
-  xpaths$table.names <- paste0(xpaths$tables, "/caption/text()")
-  xpaths$headers <- paste0(xpaths$tables, "/thead/tr[not(contains(@class, 'filterRangeRow'))]")
-  xpaths$expiries <- "//div[contains(@class, 'options_menu')]/form/select//option"
-
-  # Extract table names and headers
-  table.names <- XML::xpathSApply(tbl, xpaths$table.names, XML::xmlValue)
-  table.names <- cleanNames(table.names)
-  table.headers <- XML::xpathApply(tbl, xpaths$headers, fun=function(x) sapply(x['th'], thParse))
-  table.headers <- lapply(table.headers, cleanNames)
-
-  # Only return nearest expiry (default served by Yahoo Finance), unless the user specified Exp
-  if(!missing(Exp) && checkExp) {
-    all.expiries <- XML::xpathSApply(tbl, xpaths$expiries, XML::xmlGetAttr, name="value")
-    all.expiries.posix <- .POSIXct(as.numeric(all.expiries), tz="UTC")
-
-    if(is.null(Exp)) {
-      # Return all expiries if Exp = NULL
-      out <- lapply(all.expiries, getOptionChain.yahoo, Symbols=Symbols, .expiry.known=TRUE)
-      # Expiry format was "%b %Y", but that's not unique with weeklies. Change
-      # format to "%b.%d.%Y" ("%Y-%m-%d wouldn't be good, since names should
-      # start with a letter or dot--naming things is hard).
-      return(setNames(out, format(all.expiries.posix, "%b.%d.%Y")))
-    } else {
-      # Ensure data exist for user-provided expiry date(s)
-      if(inherits(Exp, "Date"))
-        valid.expiries <- as.Date(all.expiries.posix) %in% Exp
-      else if(inherits(Exp, "POSIXt"))
-        valid.expiries <- all.expiries.posix %in% Exp
-      else if(is.character(Exp)) {
-        expiry.range <- range(unlist(lapply(Exp, .parseISO8601, tz="UTC")))
-        valid.expiries <- all.expiries.posix >= expiry.range[1] &
-                          all.expiries.posix <= expiry.range[2]
-      }
-      if(all(!valid.expiries))
-        stop("Provided expiry date(s) not found. Available dates are: ",
-             paste(as.Date(all.expiries.posix), collapse=", "))
-
-      expiry.subset <- all.expiries[valid.expiries]
-      if(length(expiry.subset) == 1)
-        return(getOptionChain.yahoo(Symbols, expiry.subset, .expiry.known=TRUE))
-      else {
-        out <- lapply(expiry.subset, getOptionChain.yahoo, Symbols=Symbols, .expiry.known=TRUE)
-        # See comment above regarding the output names
-        return(setNames(out, format(all.expiries.posix[valid.expiries], "%b.%d.%Y")))
-      }
+  
+  getOptionChainYahoo <- function(sym, Exp)
+  {
+    url <-
+      paste("https://query2.finance.yahoo.com/v7/finance/options/",
+            Symbols,
+            sep = "")
+    if (!missing(Exp)) {
+      url <-
+        paste(
+          "https://query2.finance.yahoo.com/v7/finance/options/",
+          Symbols,
+          "?date=",
+          parse.expiry(Exp),
+          sep = ""
+        )
     }
+    
+    opt <- readLines(url)
+    opt <- paste(opt, collapse = '')
+    json <- fromJSON(opt)
+    calls <- json$optionChain$result[[1]]$options[[1]]$calls
+    puts <- json$optionChain$result[[1]]$options[[1]]$puts
+    price <- json$optionChain$result$quote$regularMarketPrice
+    
+    return (list(
+      calls = chainToDf(calls),
+      puts = chainToDf(puts),
+      price = price,
+      sym = sym
+    ))
   }
-
-  dftables <- XML::xmlApply(XML::getNodeSet(tbl, xpaths$tables), XML::readHTMLTable, stringsAsFactors=FALSE)
-  names(dftables) <- table.names
-
-  dftables <- mapply(NewToOld, x=dftables, nm=table.headers, SIMPLIFY=FALSE)
-  dftables
+  
+  chainToDf <- function(theRawList)
+  {
+    theList <- list()
+    for (i in 1:length(theRawList))
+    {
+      xx <-
+        list(
+          contractSymbol = theRawList[[i]]$contractSymbol,
+          strike = theRawList[[i]]$strike,
+          bid = theRawList[[i]]$bid,
+          ask = theRawList[[i]]$ask,
+          lastPrice = theRawList[[i]]$lastPrice,
+          volume = theRawList[[i]]$volume,
+          openInterest = theRawList[[i]]$openInterest
+        )
+      theList[[i]] <- xx
+    }
+    x <- do.call(rbind.data.frame, theList)
+    rownames(x) <- x$contractSymbol
+    y <-
+      x[, c("strike",
+            "bid",
+            "ask",
+            "lastPrice",
+            "volume",
+            "openInterest")]
+    theNames <- c("Strike", "Bid", "Ask", "Last", "Vol", "OI")
+    names(y) <- theNames
+    for (i in theNames)
+    {
+      y[, i] <- as.numeric(as.character(y[, i]))
+    }
+    return(y)
+  }
+  
+  getOptionChainYahoo(Symbols, Exp)
 }
 


### PR DESCRIPTION
This patch addresses bug #92 

Note, this patch introduces a new dependency on the "rjson" library.

Rather than scrape the HTML, this patch grabs the raw JSON for option chains from internal Yahoo URLs associated with their new AJAX framework.

If the expiration date is set, it must be accurate --- this patch provides no assistance around fixing a non-existent opex date. Further, this patch will not return results for multiple symbols or expiry dates (I think prior versions of getOptionChain might have done this).

Tested as a patch, but not as part of a package build.

Best,
Michael

