### PR TITLE
Remove all usage of archived 'its' package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(
   person(given="Wouter", family="Thielen", role="ctb")
   )
 Depends: xts(>= 0.9-0), zoo, TTR(>= 0.2), methods
-Suggests: DBI,RMySQL,RSQLite,timeSeries,its,XML,downloader,jsonlite(>= 1.1)
+Suggests: DBI,RMySQL,RSQLite,timeSeries,XML,downloader,jsonlite(>= 1.1)
 Description: Specify, build, trade, and analyse quantitative financial trading strategies.
 LazyLoad: yes
 License: GPL-3

--- a/R/getSymbols.R
+++ b/R/getSymbols.R
@@ -1128,16 +1128,6 @@ function(Symbols,env,return.class='xts',
          fr <- as.data.frame(fr)
          return(fr)
        } else
-       if('its' %in% return.class) {
-         if(requireNamespace("its", quietly=TRUE)) {
-           fr.dates <- as.POSIXct(as.character(index(fr)))
-           fr <- its::its(coredata(fr),fr.dates)
-           return(fr)
-         } else {
-           warning(paste("'its' from package 'its' could not be loaded:",
-                         " 'xts' class returned"))
-         }
-       } else 
        if('timeSeries' %in% return.class) {
          if(requireNamespace("timeSeries", quietly=TRUE)) {
            fr <- timeSeries::timeSeries(coredata(fr), charvec=as.character(index(fr)))

--- a/WISHLIST
+++ b/WISHLIST
@@ -22,7 +22,7 @@ quantmod wishlist: as of Mar 21, 2008
 
   - convert to xts from zoo throughout.  Simplify data methods [done]
   
-  - try to remove dependence on fSeries and its (etc).  Through 'xts'???
+  - try to remove dependence on fSeries (etc).  Through 'xts'???
 
 FUNCTIONALITY:
 

--- a/man/buildData.Rd
+++ b/man/buildData.Rd
@@ -15,7 +15,7 @@ of the desired output data object, with the \code{dependent} side
 corresponding to first column, and the \code{independent} parameters of
 the formula assigned to the remaining columns. }
   \item{na.rm}{ drop rows with missing values? }
-  \item{return.class}{ one of "zoo","data.frame","ts","its","timeSeries" }
+  \item{return.class}{ one of "zoo","data.frame","ts","timeSeries" }
 }
 \details{
 Makes available for use \emph{outside} the \pkg{quantmod} workflow a dataset

--- a/man/getSymbols.FRED.Rd
+++ b/man/getSymbols.FRED.Rd
@@ -47,7 +47,7 @@ A call to getSymbols.FRED will load into the specified
 environment one object for each
 \code{Symbol} specified, with class defined 
 by \code{return.class}. Presently this may be \code{ts},
-\code{its}, \code{zoo}, \code{xts}, or \code{timeSeries}.
+\code{zoo}, \code{xts}, or \code{timeSeries}.
 }
 \note{
 FRED changed its URL scheme for the downloads from http:// to

--- a/man/getSymbols.MySQL.Rd
+++ b/man/getSymbols.MySQL.Rd
@@ -30,7 +30,7 @@ getSymbols.MySQL(Symbols,
        \item{env}{ where to create objects. (.GlobalEnv)}
        \item{return.class}{ desired class of returned object.
                             Can be xts, 
-                            zoo, data.frame, ts, or its. (zoo)}
+                            zoo, data.frame, or ts. (zoo)}
        \item{db.fields}{ character vector indicating
                            names of fields to retrieve}
        \item{field.names}{ names to assign to returned columns }

--- a/man/getSymbols.Rd
+++ b/man/getSymbols.Rd
@@ -157,7 +157,7 @@ valid environment and auto.assign=TRUE,
 \code{env} one object for each
 \code{Symbol} specified, with class defined
 by \code{return.class}. Presently this may be \code{ts},
-\code{its}, \code{zoo}, \code{xts}, or \code{timeSeries}.
+\code{zoo}, \code{xts}, or \code{timeSeries}.
 
 If env=NULL or auto.assign=FALSE an object of type
 \code{return.class} will be returned.

--- a/man/getSymbols.csv.Rd
+++ b/man/getSymbols.csv.Rd
@@ -44,7 +44,7 @@ A call to getSymbols.csv will load into the specified
 environment one object for each
 \code{Symbol} specified, with class defined 
 by \code{return.class}. Presently this may be \code{ts},
-\code{its}, \code{zoo}, \code{xts}, or \code{timeSeries}.
+\code{zoo}, \code{xts}, or \code{timeSeries}.
 }
 \note{
 This has yet to be tested on a windows platform. It \emph{should} work

--- a/man/getSymbols.google.Rd
+++ b/man/getSymbols.google.Rd
@@ -53,7 +53,7 @@ A call to getSymbols.google will load into the specified
 environment one object for each
 \code{Symbol} specified, with class defined 
 by \code{return.class}. Presently this may be \code{ts},
-\code{its}, \code{zoo}, \code{xts}, or \code{timeSeries}.
+\code{zoo}, \code{xts}, or \code{timeSeries}.
 }
 \note{
 As mentioned in the details section, a serious flaw exists within

--- a/man/getSymbols.oanda.Rd
+++ b/man/getSymbols.oanda.Rd
@@ -46,7 +46,7 @@ fail with a warning that the limit has been exceeded.
 \value{
  A call to getSymbols(Symbols,src="oanda") will load into the specified
 environment one object for each 'Symbol' specified, with class
-defined  by 'return.class'. Presently this may be 'ts', 'its',
+defined  by 'return.class'. Presently this may be 'ts',
 'zoo', 'xts', or 'timeSeries'.
 }
 \note{

--- a/man/getSymbols.rda.Rd
+++ b/man/getSymbols.rda.Rd
@@ -45,7 +45,7 @@ A call to getSymbols.csv will load into the specified
 environment one object for each
 \code{Symbol} specified, with class defined 
 by \code{return.class}. Presently this may be \code{ts},
-\code{its}, \code{zoo}, \code{xts}, \code{data.frame}, 
+\code{zoo}, \code{xts}, \code{data.frame}, 
 or \code{timeSeries}.
 }
 \author{ Jeffrey A. Ryan }

--- a/man/getSymbols.yahoo.Rd
+++ b/man/getSymbols.yahoo.Rd
@@ -46,7 +46,7 @@ A call to getSymbols.yahoo will load into the specified
 environment one object for each
 \code{Symbol} specified, with class defined 
 by \code{return.class}. Presently this may be \code{ts},
-\code{its}, \code{zoo}, \code{xts}, or \code{timeSeries}.
+\code{zoo}, \code{xts}, or \code{timeSeries}.
 
 In the case of xts objects, the indexing will be by Date. This
 can be altered with the \code{index.class} argument.  See

--- a/man/getSymbols.yahooj.Rd
+++ b/man/getSymbols.yahooj.Rd
@@ -52,7 +52,7 @@ A call to getSymbols.yahooj will load into the specified
 environment one object for each
 \code{Symbol} specified, with class defined 
 by \code{return.class}. Presently this may be \code{ts},
-\code{its}, \code{zoo}, \code{xts}, or \code{timeSeries}.
+\code{zoo}, \code{xts}, or \code{timeSeries}.
 
 In the case of xts objects, the indexing will be by Date. This
 can be altered with the \code{index.class} argument.  See

--- a/man/quantmod-package.Rd
+++ b/man/quantmod-package.Rd
@@ -16,7 +16,7 @@ Type: \tab Package\cr
 Version: \tab 0.4-7\cr
 Date: \tab 2016-10-24\cr
 Depends: \tab xts(>= 0.9-0),zoo,TTR(>= 0.2),methods\cr
-Suggests: \tab DBI,RMySQL,RSQLite,timeSeries,its,XML,downloader,jsonlite(>= 1.1)\cr
+Suggests: \tab DBI,RMySQL,RSQLite,timeSeries,XML,downloader,jsonlite(>= 1.1)\cr
 LazyLoad: \tab yes\cr
 License: \tab GPL-3\cr
 URL: \tab http://www.quantmod.com\cr

--- a/man/specifyModel.Rd
+++ b/man/specifyModel.Rd
@@ -29,7 +29,7 @@ See \code{getModelData} for details of
 how this process works.
 
 Currently, objects of class \code{quantmod.OHLC},
-\code{zoo}, \code{ts} and \code{its} are supported within the
+\code{zoo} and \code{ts} are supported within the
 model formula.
 
 All symbols are first retrieved from the global environment, without inheritence.


### PR DESCRIPTION
Package 'its' has been removed from CRAN
(https://cran.r-project.org/web/packages/its/index.html) and although
it is archived it's inclusion here is making some installation scripts
like install2.r complain.

Log from `R CMD check --as-cran` attached:
[check.txt](https://github.com/joshuaulrich/quantmod/files/791138/check.txt)
