### PR TITLE
Fix timestamps formatted in scientific notation

### DIFF
--- a/R/getSymbols.R
+++ b/R/getSymbols.R
@@ -264,8 +264,8 @@ function(symbol, from, to, period, type, handle)
   e <- match.arg(type, c("history", "div", "split"))
   n <- if (unclass(Sys.time()) %% 1L >= 0.5) 1L else 2L
   u <- paste0("https://query", n, ".finance.yahoo.com/v7/finance/download/",
-              symbol, "?period1=", from, "&period2=", to, "&interval=", p,
-              "&events=", e, "&crumb=", handle$cb)
+              symbol, sprintf("?period1=%.0f&period2=%.0f", from, to),
+              "&interval=", p, "&events=", e, "&crumb=", handle$cb)
   return(u)
 }
 


### PR DESCRIPTION
UNIX timestamps with few significant digits are converted to character
in scientific notation. Today (2017-11-30) happened to be one of those
days...

R> as.character(unclass(as.POSIXct("2017-11-30", "UTC")))
[1] "1.512e+09"
R> sprintf("%.0f",unclass(as.POSIXct("2017-11-30", "UTC")))
[1] "1512000000"

This caused the Yahoo Finance URL to be malformed, which caused the
server to respond with 400-Bad Request.

Use sprintf() to ensure the number is formatted in fixed floating point
with no decimal places. I also considered using as.integer() instead of
trunc() in .dateToUNIX(), but that would cause an overflow in 20 years.

Fixes #202.