### PR TITLE
Fetch data from the Tiingo API with a getSymbols.tiingo() method.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,8 @@ Authors@R: c(
   person(given=c("Jeffrey","A."), family="Ryan", role=c("aut","cph")),
   person(given=c("Joshua","M."), family="Ulrich", role=c("cre","aut"), email="josh.m.ulrich@gmail.com"),
   person(given="Wouter", family="Thielen", role="ctb"),
-  person(given="Paul", family="Teetor", role="ctb")
+  person(given="Paul", family="Teetor", role="ctb"),
+  person(given="Steve", family="Bronder", role="ctb")
   )
 Depends: R (>= 3.2.0), xts(>= 0.9-0), zoo, TTR(>= 0.2), methods
 Imports: curl

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -256,6 +256,7 @@ export(
     getSymbols.yahoo,
     getSymbols.yahooj,
     getSymbols.oanda,
+    getSymbols.tiingo,
     #getSymbols.Bloomberg,
     #getSymbols.IBrokers,
     getSymbols.csv,

--- a/man/getSymbols.tiingo.Rd
+++ b/man/getSymbols.tiingo.Rd
@@ -10,6 +10,7 @@
   getSymbols.tiingo(Symbols, env, api.key,
                     return.class="xts",
                     periodicity="daily",
+                    adjust=FALSE,
                     from='2007-01-01',
                     to=Sys.Date(),
                     data.type="json",
@@ -22,6 +23,7 @@
   \item{api.key}{ the API key issued by Tiingo when you registered (character)}
   \item{return.class}{ class of returned object, see Value (character) }
   \item{periodicity}{ one of \code{"daily"}, \code{"weekly"}, \code{"monthly"}, or \code{"Annually"} }
+  \item{adjust}{ adjust for dividends and splits? (FALSE) }
   \item{from}{ Retrieve data no earlier than this date. (2007-01-01)}
   \item{to}{ Retrieve data through this date (Sys.Date())}
   \item{data.type}{ either \code{"json"} or \code{"csv"} }
@@ -43,6 +45,7 @@
   
   Tiingo provides daily, weekly, monthly, and annual data.
   Use \code{periodicity} to select one.
+  This API accessor will return adjusted or unadjusted OHLC as well as split and dividend information.
 
   For daily, weekly, and monthly data, Tiingo says the available data is up to 30 years;
 

--- a/man/getSymbols.tiingo.Rd
+++ b/man/getSymbols.tiingo.Rd
@@ -1,0 +1,81 @@
+\name{getSymbols.tiingo}
+\alias{getSymbols.tiingo}
+\title{ Download OHLC Data from Tiingo }
+\description{
+  Downloads historical or realtime equity price data
+  from \url{https://api.tiingo.com/}.
+  Registration is required.
+}
+\usage{
+  getSymbols.tiingo(Symbols, env, api.key,
+                    return.class="xts",
+                    periodicity="daily",
+                    from='2007-01-01',
+                    to=Sys.Date(),
+                    data.type="json",
+                    ...)
+}
+\arguments{
+  \item{Symbols}{ a character vector specifying the names
+    of the symbols to be loaded}
+  \item{env}{ where to create objects (environment) }
+  \item{api.key}{ the API key issued by Tiingo when you registered (character)}
+  \item{return.class}{ class of returned object, see Value (character) }
+  \item{periodicity}{ one of \code{"daily"}, \code{"weekly"}, \code{"monthly"}, or \code{"Annually"} }
+  \item{from}{ Retrieve data no earlier than this date. (2007-01-01)}
+  \item{to}{ Retrieve data through this date (Sys.Date())}
+  \item{data.type}{ either \code{"json"} or \code{"csv"} }
+  \item{\dots}{ additional parameters as per \code{\link{getSymbols}} }
+}
+\details{
+  Meant to be called internally by \code{getSymbols} only.
+  This method is not meant to be called directly, instead
+  a call to \code{getSymbols("x", src="tiingo")} will
+  in turn call this method. It is documented for the
+  sole purpose of highlighting the arguments accepted.
+  
+  You must register with Tiingo in order to download their data.
+  Register at their web site, \url{https://api.tiingo.com},
+  and you will receive an \emph{API key}:
+    a short string of alphanumeric characters (e.g., "FU4U").
+  Provide the API key every time you call \code{getSymbols};
+  or set it globally using \code{setDefaults(getSymbols.tiingo, api.key="yourKey")}.
+  
+  Tiingo provides daily, weekly, monthly, and annual data.
+  Use \code{periodicity} to select one.
+
+  For daily, weekly, and monthly data, Tiingo says the available data is up to 30 years;
+
+  Tiingo provides access to data via two APIs. You can choose the API via
+  the \code{data.type} argument. \code{data.type="json"}, the default, will
+  import data using the JSON API. This API includes additional metadata (e.g.
+  last updated time, timezone, etc) that is not provided via the CSV API.
+}
+\value{
+A call to \code{getSymbols(Symbols, src="tiingo")} will create objects
+in the specified environment,
+one object for each \code{Symbol} specified.
+The object class of the object(s) is determined by \code{return.class}.
+Presently this may be \code{"ts"}, \code{"zoo"}, \code{"xts"}, or \code{"timeSeries"}.
+}
+% \note{
+% [TBD]
+% }
+\references{ Tiingo documentation available at \url{https://www.tiingo.com} }
+\author{ Steve Bronder }
+\seealso{
+\code{\link{getSymbols}},
+\code{\link{getSymbols.yahoo}},
+\code{\link{getSymbols.av}}
+}
+\examples{
+\dontrun{
+# You'll need the API key given when you registered
+getSymbols("IBM", src="tiingo", api.key="yourKey")
+
+# Repeating your API key every time is tedious.
+# Fortunately, you can set a global default.
+setDefaults(getSymbols.tiingo, api.key="yourKey")
+getSymbols("IBM", src="tiingo")
+}
+}

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -30,3 +30,13 @@ options(warn = 2)
 quantmod::getSymbols("SPY", src = "google", from = Sys.Date() - 10)
 options(warn = op.warn)
 
+# should throw an error
+errorKey <- "d116c846835e633aacedb1a31959dd2724cd67b8"
+x <- try(
+  quantmod::getSymbols("AAPL", src = "tiingo", data.type = "csv", api.key = errorKey)
+, silent = TRUE)
+stopifnot(inherits(x, "try-error"))
+x <- try(
+  quantmod::getSymbols("AAPL", src = "tiingo", data.type = "json", api.key = errorKey)
+, silent = TRUE)
+stopifnot(inherits(x, "try-error"))


### PR DESCRIPTION
Commit Message:

This enables package users to download historical OHLC, Adjusted OHLC,
Dividend, and Split information from the Tiingo API. Tiingo's free
offering allows access to 60K global securities for 30+ years, though with some rate limits. Tiingo
provides daily, weekly, monthly, and annual frequencies.

Details of the service can be found at the following links
https://www.tiingo.com/pricing
https://api.tiingo.com/docs/tiingo/daily

Tiingo also provides fundamentals, mutual fund information, aggregated news feeds, crypto, and a 5 minute delay quote system, though this implementation includes no provision for downloading them.

Me:

I've been searching for good free data online and Tiingo appears to be not bad! Possibly, good! A big thing for me was that they clearly lay out the methodology for adjustments and give you the data to verify the adjustment. See the bottom of this page
https://api.tiingo.com/docs/tiingo/daily

The rate limits are reasonable for good free data. If I need more then I'll be fine with paying $10 bucks a month.

There is also a websocket API which would be cool to use, though I didn't feel like learning how to use that.
https://api.tiingo.com/docs/general/connecting

I was making this for myself and thought to submit a PR in case you wanted it. It's essentially just a copy/paste of Paul's Alpha Vantage code
