### PR TITLE
Fix getQuote.yahoo for multiple timezones

### DIFF
--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -68,14 +68,7 @@ function(Symbols,what=standardQuote(),...) {
     Qposix <- .POSIXct(sq[,"regularMarketTime"], tz=tz[1L])
   } else {
     warning("symbols have different timezones; converting to local time")
-    convertTZ <- function(x) {
-      tz <- x$exchangeTimezoneName[1]
-      times <- .POSIXct(x$regularMarketTime, tz)
-      attr(times, "tzone") <- NULL
-      times
-    }
-    Qposix <- sapply(split(sq, sq$exchangeTimezoneName), convertTZ)
-    Qposix <- .POSIXct(Qposix, tz=NULL)  # force local timezone
+    Qposix <- .POSIXct(sq$regularMarketTime, tz = NULL)  # force local timezone
   }
 
   Symbols <- unlist(strsplit(Symbols,','))


### PR DESCRIPTION
When getQuote.yahoo was called it genereted errors when quotes from multiple timezones were involved. Fixed so everything is forced to the local timezone.

Following code now works correctly:
```
library(quantmod)
metrics <- yahooQF(c("Name", "Volume", "P/E Ratio", "Dividend Yield", "Shares Outstanding"))
symbols <- c("MSFT", "GOOG", "FAGR.BR")
stats <- getQuote(symbols, what = metrics)
```

Fixes #246