### PR TITLE
279_getquote resillient to invalid symbols

### DIFF
--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -6,10 +6,19 @@
 
 `getQuote` <-
 function(Symbols,src='yahoo',what, ...) {
+  Symbols <- unique(unlist(strsplit(Symbols,";")))
   args <- list(Symbols=Symbols,...)
   if(!missing(what))
       args$what <- what
-  do.call(paste('getQuote',src,sep='.'), args)
+  r <- do.call(paste('getQuote',src,sep='.'), args)
+  if(NROW(r) != length(Symbols)){
+    r$Symbol <- rownames(r)
+    r <- merge(list(Symbol = Symbols), r,
+                  by = "Symbol", all.x = TRUE)
+    rownames(r) <- r$Symbol
+    r$Symbol <- NULL
+  }
+  return(r)
 }
 
 `getQuote.yahoo` <-

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -79,7 +79,8 @@ function(Symbols,what=standardQuote(),...) {
   Symbols <- unlist(strsplit(Symbols,','))
 
   if (length(Symbols) != NROW(sq)) {
-    sq <- merge(list(symbol = Symbols), sq, by = "symbol", all = TRUE)
+    allSymbols <- data.frame(symbol = Symbols, stringsAsFactors = FALSE)
+    sq <- merge(allSymbols, sq, by = "symbol", all = TRUE)
   }
 
   # Extract user-requested columns. Convert to list to avoid
@@ -391,7 +392,8 @@ getQuote.av <- function(Symbols, api.key, ...) {
   # merge join to produce empty rows for missing results from AV
   # so that return value has the same number of rows and order as the input
   if(length(Symbols) != NROW(r)) {
-    r <- merge(data.frame(Ticker = Symbols), r, by = "Ticker", all.x = TRUE)
+    allSymbols <- data.frame(Ticker = Symbols, stringsAsFactors = FALSE)
+    r <- merge(allSymbols, r, by = "Ticker", all.x = TRUE)
   }
 
   rownames(r) <- r$Ticker

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -79,7 +79,6 @@ function(Symbols,what=standardQuote(),...) {
   # Add the trade time and setNames() on other elements
   qflist <- c(list(regularMarketTime = Qposix), setNames(qflist, QF))
   
-
   df <- data.frame(qflist, stringsAsFactors = FALSE, check.names = FALSE)
 
   rownames(df) <- Symbols
@@ -88,7 +87,6 @@ function(Symbols,what=standardQuote(),...) {
   }
   df
 }
-
 
 # integrate this into the main getQuote.yahoo, after branching that
 #

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -69,6 +69,8 @@ function(Symbols,what=standardQuote(),...) {
 
   Symbols <- unlist(strsplit(Symbols,','))
 
+  # merge join to produce empty rows for missing results, so that
+  # return value has the same number of rows and order as the input
   if (length(Symbols) != NROW(sq)) {
     allSymbols <- data.frame(symbol = Symbols, stringsAsFactors = FALSE)
     sq <- merge(allSymbols, sq, by = "symbol", all = TRUE)
@@ -380,8 +382,8 @@ getQuote.av <- function(Symbols, api.key, ...) {
   r[, "Trade Time"] <- r[, "LastSaleTimestamp"]
   r[, "LastSaleTimestamp"] <- NULL
 
-  # merge join to produce empty rows for missing results from AV
-  # so that return value has the same number of rows and order as the input
+  # merge join to produce empty rows for missing results, so that
+  # return value has the same number of rows and order as the input
   if(length(Symbols) != NROW(r)) {
     allSymbols <- data.frame(Ticker = Symbols, stringsAsFactors = FALSE)
     r <- merge(allSymbols, r, by = "Ticker", all.x = TRUE)

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -6,19 +6,10 @@
 
 `getQuote` <-
 function(Symbols,src='yahoo',what, ...) {
-  Symbols <- unique(unlist(strsplit(Symbols,";")))
   args <- list(Symbols=Symbols,...)
   if(!missing(what))
       args$what <- what
-  r <- do.call(paste('getQuote',src,sep='.'), args)
-  if(NROW(r) != length(Symbols)){
-    r$Symbol <- rownames(r)
-    r <- merge(list(Symbol = Symbols), r,
-                  by = "Symbol", all.x = TRUE)
-    rownames(r) <- r$Symbol
-    r$Symbol <- NULL
-  }
-  return(r)
+  do.call(paste('getQuote',src,sep='.'), args)
 }
 
 `getQuote.yahoo` <-

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -304,14 +304,14 @@ getQuote.av <- function(Symbols, api.key, ...) {
     }
   }
 
-  #Format output
   colnames(result) <- c("Symbol", "Last", "Volume", "Trade Time")
   result$Volume <- suppressWarnings(as.numeric(result$Volume))
   result$Last <- as.numeric(result$Last)
   quoteTZ <- response[["Meta Data"]][["3. Time Zone"]]
   result$`Trade Time` <- as.POSIXct(result$`Trade Time`, tz = quoteTZ)
+
+  #Format output
   rownames(result) <- result$Symbol
-  
   return(result[, c("Trade Time", "Last", "Volume")])
 }
 

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -76,7 +76,7 @@ function(Symbols,what=standardQuote(),...) {
   # Fill any missing columns with NA
   pad <- rep(NA, length(Symbols))
   qflist <- lapply(qflist, function(e) if (is.null(e)) pad else e)
-  
+
   # Add the trade time and setNames() on other elements
   qflist <- c(list(regularMarketTime = Qposix), setNames(qflist, QF))
 
@@ -88,6 +88,7 @@ function(Symbols,what=standardQuote(),...) {
   }
   df
 }
+
 
 # integrate this into the main getQuote.yahoo, after branching that
 #

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -76,9 +76,10 @@ function(Symbols,what=standardQuote(),...) {
   # Fill any missing columns with NA
   pad <- rep(NA, length(Symbols))
   qflist <- lapply(qflist, function(e) if (is.null(e)) pad else e)
+  
   # Add the trade time and setNames() on other elements
   qflist <- c(list(regularMarketTime = Qposix), setNames(qflist, QF))
-  
+
   df <- data.frame(qflist, stringsAsFactors = FALSE, check.names = FALSE)
 
   rownames(df) <- Symbols

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -303,7 +303,6 @@ getQuote.av <- function(Symbols, api.key, ...) {
       result <- rbind(result, response[["Stock Quotes"]])
     }
   }
-
   colnames(result) <- c("Symbol", "Last", "Volume", "Trade Time")
   result$Volume <- suppressWarnings(as.numeric(result$Volume))
   result$Last <- as.numeric(result$Last)

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -390,7 +390,7 @@ getQuote.av <- function(Symbols, api.key, ...) {
 
   # merge join to produce empty rows for missing results from AV
   # so that return value has the same number of rows and order as the input
-  if(NROW(r) != length(Symbols)) {
+  if(length(Symbols) != NROW(r)) {
     r <- merge(data.frame(Ticker = Symbols), r, by = "Ticker", all.x = TRUE)
   }
 

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -82,7 +82,7 @@ function(Symbols,what=standardQuote(),...) {
     sq <- merge(list(symbol = Symbols), sq, by = "symbol", all = TRUE)
   }
 
-    # Extract user-requested columns. Convert to list to avoid
+  # Extract user-requested columns. Convert to list to avoid
   # 'undefined column' error with data.frame.
   qflist <- setNames(as.list(sq)[QF], QF)
 
@@ -385,14 +385,15 @@ getQuote.av <- function(Symbols, api.key, ...) {
   }
 
   colnames(r) <- gsub("(^[[:alpha:]])", "\\U\\1", colnames(r), perl = TRUE)
-  colnames(r)[which(colnames(r) == "LastsaleTimeStamp")] <- "Trade Time"
+  r[, "Trade Time"] <- r[, "LastSaleTimestamp"]
+  r[, "LastSaleTimestamp"] <- NULL
 
   # merge join to produce empty rows for missing results from AV
   # so that return value has the same number of rows and order as the input
   if(NROW(r) != length(Symbols)) {
     r <- merge(data.frame(Ticker = Symbols), r, by = "Ticker", all.x = TRUE)
   }
-  
+
   rownames(r) <- r$Ticker
   std.cols <- c("Trade Time", "Open", "High", "Low", "Last", "Volume")
   return(r[, c(std.cols, setdiff(colnames(r), c(std.cols, "Ticker")))])

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -34,3 +34,6 @@ x <- try(
   quantmod::getSymbols("AAPL", src = "tiingo", data.type = "json", api.key = errorKey)
 , silent = TRUE)
 stopifnot(inherits(x, "try-error"))
+
+x <- try(quantmod::getQuote("SPY;WYSIWYG", src = "yahoo"), silent = TRUE)
+stopifnot(inherits(x, "data.frame") && rownames(x) == c("SPY", "WYSIWYG"))

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -1,3 +1,6 @@
+av.key <- Sys.getenv("AV_API_KEY")
+tiingo.key <- Sys.getenv("TIINGO_API_KEY")
+
 # Call as.zoo before quantmod is loaded and registers its S3 method
 dc <- c("2015-01-01", "2016-01-01", "2017-01-01")
 dd <- as.Date(dc)
@@ -35,5 +38,16 @@ x <- try(
 , silent = TRUE)
 stopifnot(inherits(x, "try-error"))
 
-x <- try(quantmod::getQuote("SPY;WYSIWYG", src = "yahoo"), silent = TRUE)
-stopifnot(inherits(x, "data.frame") && rownames(x) == c("SPY", "WYSIWYG"))
+syms <- c("SPY", "WYSIWYG")
+symstr <- paste(syms, collapse = ";")
+x <- try(getQuote(symstr, src = "yahoo"), silent = TRUE)
+stopifnot(inherits(x, "data.frame") && all(rownames(x) == syms))
+
+if (av.key != "") {
+  x <- try(getQuote(symstr, src = "av", api.key = av.key), silent = TRUE)
+  stopifnot(inherits(x, "data.frame") && all(rownames(x) == syms))
+}
+if (tiingo.key != "") {
+  x <- try(getQuote(symstr, src = "tiingo", api.key = tiingo.key), silent = TRUE)
+  stopifnot(inherits(x, "data.frame") && all(rownames(x) == syms))
+}


### PR DESCRIPTION
getQuote would fail if the source did not recognize any of the supplied symbols. this was particularly problematic on large batches where a single failure would cause a stop and there was no way to diagnose which symbol had caused the problem

all getQuote paths now support ";" delimited inputs 
All getQuote paths now return NA rows for missing quotes

