### PR TITLE
289 add adjusted to output

### DIFF
--- a/R/getSymbols.R
+++ b/R/getSymbols.R
@@ -1534,7 +1534,6 @@ getSymbols.tiingo <- function(Symbols, env, api.key,
       stock.data <- stock.data[, c("open", "high", "low", "close", "volume", "adjClose")]
       colnames(stock.data) <- paste(sym, c("Open", "High", "Low", "Close", "Volume", "Adjusted"), sep=".")
     }
-    
 
     # convert data to xts
     xts.data <- xts(stock.data, tm.stamps, src="tiingo", updated=Sys.time())

--- a/R/getSymbols.R
+++ b/R/getSymbols.R
@@ -1529,10 +1529,12 @@ getSymbols.tiingo <- function(Symbols, env, api.key,
     tm.stamps <- as.POSIXct(stock.data[, "date"], ...)
     if (adjust) {
       stock.data <- stock.data[, c("adjOpen", "adjHigh", "adjLow", "adjClose", "adjVolume")]
+      colnames(stock.data) <- paste(sym, c("Open", "High", "Low", "Close", "Volume"), sep=".")
     } else {
-      stock.data <- stock.data[, c("open", "high", "low", "close", "volume")]
+      stock.data <- stock.data[, c("open", "high", "low", "close", "volume", "adjClose")]
+      colnames(stock.data) <- paste(sym, c("Open", "High", "Low", "Close", "Volume", "Adjusted"), sep=".")
     }
-    colnames(stock.data) <- paste(sym, c("Open", "High", "Low", "Close", "Volume"), sep=".")
+    
 
     # convert data to xts
     xts.data <- xts(stock.data, tm.stamps, src="tiingo", updated=Sys.time())


### PR DESCRIPTION
adds the adjusted close to output with unadjusted data, following the yahoo pattern
this is the simplest approach i could think of that exposes both the adjusted and unadjusted data in a way that is compatible with other existing sources, doesnt break any existing contract (both implied and specified) and doesnt require a radical re-design of the API.

partially addresses #289