### PR TITLE
fix_382

### DIFF
--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -26,6 +26,7 @@ function(Symbols,src='yahoo',what, ...) {
 
 .yahooSession <- function() {
   h <- curl::new_handle()
+  #yahoo finance doesnt seem to set cookies wihtout these headers and the cookies are needed
   curl::handle_setheaders(h, accept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
   r <- curl::curl_fetch_memory("https://finance.yahoo.com", handle = h)
   n <- if (unclass(Sys.time()) %% 1L >= 0.5) 1L else 2L

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -55,9 +55,8 @@ function(Symbols,src='yahoo',what, ...) {
 }
 
 `getQuote.yahoo` <-
-function(Symbols,what=standardQuote(),yahoo.session = NULL,...) {
+function(Symbols,what=standardQuote(),...) {
   importDefaults("getQuote.yahoo")
-  if (is.null(yahoo.session)) yahoo.session <- .yahooSession()
   length.of.symbols <- length(Symbols)
   if(length.of.symbols > 200) {
     # yahoo only works with 200 symbols or less per call
@@ -69,7 +68,7 @@ function(Symbols,what=standardQuote(),yahoo.session = NULL,...) {
     for(i in 1:length(all.symbols)) {
       Sys.sleep(0.5)
       cat(i,", ")
-      df <- rbind(df, getQuote.yahoo(all.symbols[[i]],what,yahoo.session = yahoo.session))
+      df <- rbind(df, getQuote.yahoo(all.symbols[[i]],what))
     }
     cat("...done\n")
     return(df)
@@ -89,12 +88,11 @@ function(Symbols,what=standardQuote(),yahoo.session = NULL,...) {
   # exchange, fullExchangeName, market, sourceInterval, exchangeTimezoneName,
   # exchangeTimezoneShortName, gmtOffSetMilliseconds, tradeable, symbol
   QFc <- paste0(QF,collapse=',')
-  URL <- paste0("https://query1.finance.yahoo.com/v7/finance/quote?symbols=",
+  URL <- paste0("https://query1.finance.yahoo.com/v6/finance/quote?symbols=",
                 SymbolsString,
-                "&crumb=", yahoo.session$crumb,
                 "&fields=",QFc)
   # The 'response' data.frame has fields in columns and symbols in rows
-  response <- jsonlite::fromJSON(curl::curl(URL, handle = yahoo.session$h))
+  response <- jsonlite::fromJSON(curl::curl(URL))
   if (is.null(response$quoteResponse$error)) {
     sq <- response$quoteResponse$result
   } else {

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -45,9 +45,9 @@ function(Symbols,src='yahoo',what, ...) {
     #get a crumb so that downstream callers dont have to handle invalid sessions.
     #this is a network hop, but very lightweight payload
     n <- if (unclass(Sys.time()) %% 1L >= 0.5) 1L else 2L
-    query.srv <- paste0("https://query", n, ".finance.yahoo.com/", "v1/test/getcrumb")
+    query.srv <- paste0("https://query", n, ".finance.yahoo.com/v1/test/getcrumb")
     r <- curl::curl_fetch_memory(query.srv, handle = ses$h)
-    if (r$status_code == 200) {
+    if ((r$status_code == 200) && (length(r$content) > 0)) {
       ses$crumb = rawToChar(r$content)
     } else {
       if (!force.new) ses <- .yahooSession(TRUE) else stop("Unbale to get yahoo crumb")

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -36,8 +36,8 @@ function(Symbols,src='yahoo',what, ...) {
     curl::handle_setheaders(ses$h, accept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
     URL <- "https://finance.yahoo.com"
     r <- curl::curl_fetch_memory(URL, handle = ses$h)
-    #yahoo redirects to a consent form for GDPR, so urls will differ
-    ses$can.crumb <- ((r$status_code == 200) && (URL == r$url))
+    #yahoo redirects to a consent form w/ a single cookie for GDPR:
+    ses$can.crumb <- ((r$status_code == 200) && (URL == r$url) && (NROW(curl::handle_cookies(ses$h)) > 1))
     assign(cache.name, ses, .quantmodEnv) #cache session
   }
 

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -34,9 +34,10 @@ function(Symbols,src='yahoo',what, ...) {
     #yahoo finance doesn't seem to set cookies without these headers 
     #and the cookies are needed to get the crumb
     curl::handle_setheaders(ses$h, accept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
-    URL <- "https://finance.yahoo.com"
+    URL <- "https://finance.yahoo.com/"
     r <- curl::curl_fetch_memory(URL, handle = ses$h)
     #yahoo redirects to a consent form w/ a single cookie for GDPR:
+    #detecting the redirect seems very brittle as its sensitive to the trailing "/"
     ses$can.crumb <- ((r$status_code == 200) && (URL == r$url) && (NROW(curl::handle_cookies(ses$h)) > 1))
     assign(cache.name, ses, .quantmodEnv) #cache session
   }
@@ -50,7 +51,7 @@ function(Symbols,src='yahoo',what, ...) {
     if ((r$status_code == 200) && (length(r$content) > 0)) {
       ses$crumb = rawToChar(r$content)
     } else {
-      if (!force.new) ses <- .yahooSession(TRUE) else stop("Unbale to get yahoo crumb")
+      if (!force.new) ses <- .yahooSession(TRUE) else stop("Unable to get yahoo crumb")
     }
   }
 

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -24,15 +24,34 @@ function(Symbols,src='yahoo',what, ...) {
   df[Symbols,]
 }
 
-.yahooSession <- function() {
-  h <- curl::new_handle()
-  #yahoo finance doesnt seem to set cookies wihtout these headers and the cookies are needed
-  curl::handle_setheaders(h, accept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
-  r <- curl::curl_fetch_memory("https://finance.yahoo.com", handle = h)
+.yahooSession <- function(force.new = FALSE) {
+  cache.name <- "_yahoo_curl_handle_"
+  h <- get0(cache.name, .quantmodEnv) #get cached handle
+  
+  if (is.null(h) || force.new) {
+    h <- curl::new_handle()
+    #yahoo finance doesn't seem to set cookies without these headers and the
+    #cookies are needed to get the crumb
+    curl::handle_setheaders(h, accept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
+    r <- curl::curl_fetch_memory("https://finance.yahoo.com", handle = h)
+    if ((r$status_code != 200) || (NROW(curl::handle_cookies(h)) < 1)) 
+      stop("Unable to start yahoo session")
+  }
+
+  #test that we can get a crumb on each call, so that downstream callers dont 
+  #have to handle invalid sessions. while getting the crumb on each call is an
+  #extra network roundtrip, its a very small paylod, so still quite lightweight
   n <- if (unclass(Sys.time()) %% 1L >= 0.5) 1L else 2L
   query.srv <- paste0("https://query", n, ".finance.yahoo.com/", "v1/test/getcrumb")
-  r <- curl::curl_fetch_memory(query.srv, handle = h)
-  list(h = h, crumb = rawToChar(r$content))
+  r <- try(curl::curl_fetch_memory(query.srv, handle = h))
+  if (inherits(r, "try-error") || (r$status_code != 200)) {
+    if (!force.new) ses <- .yahooSession(TRUE) else stop(r)
+  } else {
+    ses <- list(h = h, crumb = rawToChar(r$content))
+    assign(cache.name, h, .quantmodEnv) #cache handle, not session
+  }
+
+  return(ses)
 }
 
 `getQuote.yahoo` <-

--- a/R/getQuote.R
+++ b/R/getQuote.R
@@ -37,7 +37,7 @@ function(Symbols,src='yahoo',what, ...) {
     URL <- "https://finance.yahoo.com"
     r <- curl::curl_fetch_memory(URL, handle = ses$h)
     #yahoo redirects to a consent form for GDPR, so urls will differ
-    ses$can.crumb <- (URL == r$url)
+    ses$can.crumb <- ((r$status_code == 200) && (URL == r$url))
     assign(cache.name, ses, .quantmodEnv) #cache session
   }
 


### PR DESCRIPTION
adds a lightweight session for use on yahoo quote requests
session is needed for both the cookies and the "crumb" field
the handle from the session must also be used for subsequent requests
fixes #382