### PR TITLE
fix_has_ohlcv_305

### DIFF
--- a/R/OHLC.transformations.R
+++ b/R/OHLC.transformations.R
@@ -221,7 +221,7 @@ function(x,which=FALSE)
     return(if(which) colAttr else TRUE)
 
   loc <- grep('\\bOpen\\b',colnames(x),ignore.case=TRUE)
-  if (length(loc) > 1) loc <- grep('\\.Open\\b',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Open$',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -244,7 +244,7 @@ function(x,which=FALSE)
     return(if(which) colAttr else TRUE)
 
   loc <- grep('\\bHigh\\b',colnames(x),ignore.case=TRUE)
-  if (length(loc) > 1) loc <- grep('\\.High\\b',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.High$',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -267,7 +267,7 @@ function(x,which=FALSE)
     return(if(which) colAttr else TRUE)
 
   loc <- grep('\\bLow\\b',colnames(x),ignore.case=TRUE)
-  if (length(loc) > 1) loc <- grep('\\.Low\\b',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Low$',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -289,7 +289,7 @@ function(x,which=FALSE)
     return(if(which) colAttr else TRUE)
 
   loc <- grep('\\bClose\\b',colnames(x),ignore.case=TRUE)
-  if (length(loc) > 1) loc <- grep('\\.Close\\b',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Close$',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE

--- a/R/OHLC.transformations.R
+++ b/R/OHLC.transformations.R
@@ -207,9 +207,10 @@ function(x)
 `Op` <-
 function(x)
 {
-  if(has.Op(x))
-    return(x[,grep('Open',colnames(x),ignore.case=TRUE)])
-  stop('subscript out of bounds: no column name containing "Open"')
+  loc <- has.Op(x,which = TRUE)
+  if ((length(loc) == 1) && (is.numeric(loc)))
+      return(x[,loc])
+  stop('subscript out of bounds: no or multiple column name containing "Open"')
 }
 
 `has.Op` <-
@@ -220,6 +221,7 @@ function(x,which=FALSE)
     return(if(which) colAttr else TRUE)
 
   loc <- grep('Open',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Open',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -228,9 +230,10 @@ function(x,which=FALSE)
 `Hi` <-
 function(x)
 {
-  if(has.Hi(x))
-    return(x[,grep('High',colnames(x),ignore.case=TRUE)])
-  stop('subscript out of bounds: no column name containing "High"')
+  loc <- has.Hi(x,which = TRUE)
+  if ((length(loc) == 1) && (is.numeric(loc)))
+      return(x[,loc])
+  stop('subscript out of bounds: no or multiple column name containing "High"')
 }
 
 `has.Hi` <-
@@ -241,6 +244,7 @@ function(x,which=FALSE)
     return(if(which) colAttr else TRUE)
 
   loc <- grep('High',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.High',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -249,9 +253,10 @@ function(x,which=FALSE)
 `Lo` <-
 function(x)
 {
-  if(has.Lo(x))
-    return(x[,grep('Low',colnames(x),ignore.case=TRUE)])
-  stop('subscript out of bounds: no column name containing "Low"')
+  loc <- has.Lo(x,which = TRUE)
+  if ((length(loc) == 1) && (is.numeric(loc)))
+      return(x[,loc])
+  stop('subscript out of bounds: no or multiple column name containing "Low"')
 }
 
 `has.Lo` <-
@@ -262,6 +267,7 @@ function(x,which=FALSE)
     return(if(which) colAttr else TRUE)
 
   loc <- grep('Low',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Low',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -270,9 +276,10 @@ function(x,which=FALSE)
 `Cl` <-
 function(x)
 {
-  if(has.Cl(x))
-    return(x[,grep('Close',colnames(x),ignore.case=TRUE)])
-  stop('subscript out of bounds: no column name containing "Close"')
+  loc <- has.Cl(x,which = TRUE)
+  if ((length(loc) == 1) && (is.numeric(loc)))
+      return(x[,loc])
+  stop('subscript out of bounds: no or multiple column name containing "Close"')
 }
 `has.Cl` <-
 function(x,which=FALSE)
@@ -282,6 +289,7 @@ function(x,which=FALSE)
     return(if(which) colAttr else TRUE)
 
   loc <- grep('Close',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Close',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -290,11 +298,10 @@ function(x,which=FALSE)
 `Vo` <-
 function(x)
 {
-  #vo <- grep('Volume',colnames(x))
-  #if(!identical(vo,integer(0)))
-  if(has.Vo(x))
-    return(x[,grep('Volume',colnames(x),ignore.case=TRUE)])
-  stop('subscript out of bounds: no column name containing "Volume"')
+  loc <- has.Vo(x,which = TRUE)
+  if ((length(loc) == 1) && (is.numeric(loc)))
+      return(x[,loc])
+  stop('subscript out of bounds: no or multiple column name containing "Volume"')
 }
 `has.Vo` <-
 function(x,which=FALSE)
@@ -304,6 +311,7 @@ function(x,which=FALSE)
     return(if(which) colAttr else TRUE)
 
   loc <- grep('Volume',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Volume',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -312,9 +320,10 @@ function(x,which=FALSE)
 `Ad` <-
 function(x)
 {
-  if(has.Ad(x))
-    return(x[,grep('Adjusted',colnames(x),ignore.case=TRUE)])
-  stop('subscript out of bounds: no column name containing "Adjusted"')
+  loc <- has.Ad(x,which = TRUE)
+  if ((length(loc) == 1) && (is.numeric(loc)))
+      return(x[,loc])
+  stop('subscript out of bounds: no or multiple column name containing "Adjusted"')
 }
 `has.Ad` <-
 function(x,which=FALSE)
@@ -324,6 +333,7 @@ function(x,which=FALSE)
     return(if(which) colAttr else TRUE)
 
   loc <- grep('Adjusted',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Adjusted',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE

--- a/R/OHLC.transformations.R
+++ b/R/OHLC.transformations.R
@@ -220,8 +220,8 @@ function(x,which=FALSE)
   if(!is.null(colAttr))
     return(if(which) colAttr else TRUE)
 
-  loc <- grep('Open',colnames(x),ignore.case=TRUE)
-  if (length(loc) > 1) loc <- grep('\\.Open',colnames(x),ignore.case=TRUE)
+  loc <- grep('\\bOpen\\b',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Open\\b',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -243,8 +243,8 @@ function(x,which=FALSE)
   if(!is.null(colAttr))
     return(if(which) colAttr else TRUE)
 
-  loc <- grep('High',colnames(x),ignore.case=TRUE)
-  if (length(loc) > 1) loc <- grep('\\.High',colnames(x),ignore.case=TRUE)
+  loc <- grep('\\bHigh\\b',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.High\\b',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -266,8 +266,8 @@ function(x,which=FALSE)
   if(!is.null(colAttr))
     return(if(which) colAttr else TRUE)
 
-  loc <- grep('Low',colnames(x),ignore.case=TRUE)
-  if (length(loc) > 1) loc <- grep('\\.Low',colnames(x),ignore.case=TRUE)
+  loc <- grep('\\bLow\\b',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Low\\b',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -288,8 +288,8 @@ function(x,which=FALSE)
   if(!is.null(colAttr))
     return(if(which) colAttr else TRUE)
 
-  loc <- grep('Close',colnames(x),ignore.case=TRUE)
-  if (length(loc) > 1) loc <- grep('\\.Close',colnames(x),ignore.case=TRUE)
+  loc <- grep('\\bClose\\b',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Close\\b',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -310,8 +310,8 @@ function(x,which=FALSE)
   if(!is.null(colAttr))
     return(if(which) colAttr else TRUE)
 
-  loc <- grep('Volume',colnames(x),ignore.case=TRUE)
-  if (length(loc) > 1) loc <- grep('\\.Volume',colnames(x),ignore.case=TRUE)
+  loc <- grep('\\bVolume\\b',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Volume\\b',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE
@@ -332,8 +332,8 @@ function(x,which=FALSE)
   if(!is.null(colAttr))
     return(if(which) colAttr else TRUE)
 
-  loc <- grep('Adjusted',colnames(x),ignore.case=TRUE)
-  if (length(loc) > 1) loc <- grep('\\.Adjusted',colnames(x),ignore.case=TRUE)
+  loc <- grep('\\bAdjusted\\b',colnames(x),ignore.case=TRUE)
+  if (length(loc) > 1) loc <- grep('\\.Adjusted\\b',colnames(x),ignore.case=TRUE)
   if(!identical(loc,integer(0))) {
     return(if(which) loc else TRUE)
   } else FALSE

--- a/tests/test_has.R
+++ b/tests/test_has.R
@@ -27,6 +27,10 @@ colnames(d) <- paste("ILOW", simple.colnames, sep = ".")
 expect_equal(has.OHLC(d), TRUE)
 expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
 
-colnames(d) <- paste("HIGHW", simple.colnames, sep = ".")
+colnames(d) <- paste("LOW.W", simple.colnames, sep = ".")
+expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+
+colnames(d) <- paste("My.LOW", simple.colnames, sep = ".")
 expect_equal(has.OHLC(d), TRUE)
 expect_equal(has.OHLC(d, which = T), c(1,2,3,4))

--- a/tests/test_has.R
+++ b/tests/test_has.R
@@ -9,31 +9,31 @@ simple.colnames <- c("Open", "High", "Low", "Close", "Volume", "Adjusted")
 
 #has.OHLC will test underlying has.op, hasCl, etc
 colnames(stock) <- simple.colnames
-expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_true(all(has.OHLC(stock)))
 expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
 colnames(stock) <- paste("OPEN", simple.colnames, sep = ".")
-expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_true(all(has.OHLC(stock)))
 expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
 colnames(stock) <- paste("HIGH", simple.colnames, sep = ".")
-expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_true(all(has.OHLC(stock)))
 expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
 colnames(stock) <- paste("LOW", simple.colnames, sep = ".")
-expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_true(all(has.OHLC(stock)))
 expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
 colnames(stock) <- paste("ILOW", simple.colnames, sep = ".")
-expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_true(all(has.OHLC(stock)))
 expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
 colnames(stock) <- paste("LOW.W", simple.colnames, sep = ".")
-expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_true(all(has.OHLC(stock)))
 expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
 colnames(stock) <- paste("My.LOW", simple.colnames, sep = ".")
-expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_true(all(has.OHLC(stock)))
 expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
 expect_true(has.Op(stock))
@@ -114,3 +114,8 @@ colnames(stock) <- gsub("MSFT", "ADJUSTED", cols)
 expect_true(has.Ad(stock))
 expect_equal(has.Ad(stock, which = TRUE), 6)
 expect_identical(colnames(Ad(stock)), colnames(stock)[6])
+
+colnames(stock) <- simple.colnames
+stock$slowD <- stock[,4]
+expect_true(all(has.OHLC(stock)))
+expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))

--- a/tests/test_has.R
+++ b/tests/test_has.R
@@ -115,6 +115,7 @@ expect_true(has.Ad(stock))
 expect_equal(has.Ad(stock, which = TRUE), 6)
 expect_identical(colnames(Ad(stock)), colnames(stock)[6])
 
+# low in colname returned by function TTR::stoch()
 colnames(stock) <- simple.colnames
 stock$slowD <- stock[,4]
 expect_true(all(has.OHLC(stock)))

--- a/tests/test_has.R
+++ b/tests/test_has.R
@@ -2,34 +2,115 @@ library(quantmod)
 library(tinytest)
 
 data(sample_matrix, package = "xts")
-d <- as.xts(sample_matrix)
-simple.colnames <- c("Open", "High", "Low", "Close")
+stock <- as.xts(sample_matrix)
+stock$Volume <- stock$Close
+stock$Adjusted <- stock$Close
+simple.colnames <- c("Open", "High", "Low", "Close", "Volume", "Adjusted")
 
 #has.OHLC will test underlying has.op, hasCl, etc
-colnames(d) <- simple.colnames
-expect_equal(has.OHLC(d), rep(TRUE,4))
-expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+colnames(stock) <- simple.colnames
+expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
-colnames(d) <- paste("OPEN", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), rep(TRUE,4))
-expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+colnames(stock) <- paste("OPEN", simple.colnames, sep = ".")
+expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
-colnames(d) <- paste("HIGH", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), rep(TRUE,4))
-expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+colnames(stock) <- paste("HIGH", simple.colnames, sep = ".")
+expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
-colnames(d) <- paste("LOW", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), rep(TRUE,4))
-expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+colnames(stock) <- paste("LOW", simple.colnames, sep = ".")
+expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
-colnames(d) <- paste("ILOW", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), rep(TRUE,4))
-expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+colnames(stock) <- paste("ILOW", simple.colnames, sep = ".")
+expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
-colnames(d) <- paste("LOW.W", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), rep(TRUE,4))
-expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+colnames(stock) <- paste("LOW.W", simple.colnames, sep = ".")
+expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
-colnames(d) <- paste("My.LOW", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), rep(TRUE,4))
-expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+colnames(stock) <- paste("My.LOW", simple.colnames, sep = ".")
+expect_equal(has.OHLC(stock), rep(TRUE,4))
+expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
+
+expect_true(has.Op(stock))
+expect_true(has.Hi(stock))
+expect_true(has.Lo(stock))
+expect_true(has.Cl(stock))
+expect_true(has.Vo(stock))
+expect_true(is.HLC(stock))
+expect_true(all(has.HLC(stock)))
+expect_true(is.OHLC(stock))
+expect_true(all(has.OHLC(stock)))
+expect_true(is.OHLCV(stock))
+expect_true(all(has.OHLCV(stock)))
+
+# Test which for has/OHLC functions.
+expect_equal(has.Op(stock, which = TRUE), 1)
+expect_equal(has.Hi(stock, which = TRUE), 2)
+expect_equal(has.Lo(stock, which = TRUE), 3)
+expect_equal(has.Cl(stock, which = TRUE), 4)
+expect_equal(has.Vo(stock, which = TRUE), 5)
+expect_equal(has.HLC(stock, which = TRUE), c(2,3,4))
+expect_equal(has.OHLC(stock, which = TRUE), c(1,2,3,4))
+expect_equal(has.OHLCV(stock, which = TRUE), c(1,2,3,4,5))
+
+# Test return correct OHLC column(s).
+expect_identical(colnames(Op(stock)), cols[1])
+expect_identical(colnames(Hi(stock)), cols[2])
+expect_identical(colnames(Lo(stock)), cols[3])
+expect_identical(colnames(Cl(stock)), cols[4])
+expect_identical(colnames(HLC(stock)), cols[c(2,3,4)])
+expect_identical(colnames(OHLC(stock)), cols[c(1,2,3,4)])
+expect_identical(colnames(OHLCV(stock)), cols[c(1,2,3,4,5)])
+
+# Test sample matrix regression
+data(sample_matrix, package = "xts")
+sample <- as.xts(sample_matrix)
+expect_equal(has.Op(sample, which = TRUE), 1)
+expect_equal(has.Hi(sample, which = TRUE), 2)
+expect_equal(has.Lo(sample, which = TRUE), 3)
+expect_equal(has.Cl(sample, which = TRUE), 4)
+expect_identical(colnames(Op(sample)), "Open")
+expect_identical(colnames(Hi(sample)), "High")
+expect_identical(colnames(Lo(sample)), "Low")
+expect_identical(colnames(Cl(sample)), "Close")
+
+# Test "Open" columns with symbol "OPEN".
+colnames(stock) <- gsub("MSFT", "OPEN", cols)
+expect_true(has.Op(stock))
+expect_equal(has.Op(stock, which = TRUE), 1)
+expect_identical(colnames(Op(stock)), colnames(stock)[1])
+
+# Test "High" columns with symbol "HIGH".
+colnames(stock) <- gsub("MSFT", "HIGH", cols)
+expect_true(has.Hi(stock))
+expect_equal(has.Hi(stock, which = TRUE), 2)
+expect_identical(colnames(Hi(stock)), colnames(stock)[2])
+
+# Test "Low" columns with symbol "LOW".
+colnames(stock) <- gsub("MSFT", "LOW", cols)
+expect_true(has.Lo(stock))
+expect_equal(has.Lo(stock, which = TRUE), 3)
+expect_identical(colnames(Lo(stock)), colnames(stock)[3])
+
+# Test "Close" columns with symbol "CLOSE".
+colnames(stock) <- gsub("MSFT", "CLOSE", cols)
+expect_true(has.Cl(stock))
+expect_equal(has.Cl(stock, which = TRUE), 4)
+expect_identical(colnames(Cl(stock)), colnames(stock)[4])
+
+# Test "Volume" columns with symbol "VOLUME".
+colnames(stock) <- gsub("MSFT", "VOLUME", cols)
+expect_true(has.Vo(stock))
+expect_equal(has.Vo(stock, which = TRUE), 5)
+expect_identical(colnames(Vo(stock)), colnames(stock)[5])
+
+# Test "Adjusted" columns with symbol "ADJUSTED".
+colnames(stock) <- gsub("MSFT", "ADJUSTED", cols)
+expect_true(has.Ad(stock))
+expect_equal(has.Ad(stock, which = TRUE), 6)
+expect_identical(colnames(Ad(stock)), colnames(stock)[6])

--- a/tests/test_has.R
+++ b/tests/test_has.R
@@ -1,0 +1,32 @@
+library(quantmod)
+library(tinytest)
+
+data(sample_matrix, package = "xts")
+d <- as.xts(sample_matrix)
+simple.colnames <- c("Open", "High", "Low", "Close")
+
+
+#has.OHLC will test has.op, has,cl, etc
+colnames(d) <- simple.colnames
+expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+
+colnames(d) <- paste("OPEN", simple.colnames, sep = ".")
+expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+
+colnames(d) <- paste("HIGH", simple.colnames, sep = ".")
+expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+
+colnames(d) <- paste("LOW", simple.colnames, sep = ".")
+expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+
+colnames(d) <- paste("ILOW", simple.colnames, sep = ".")
+expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
+
+colnames(d) <- paste("HIGHW", simple.colnames, sep = ".")
+expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d, which = T), c(1,2,3,4))

--- a/tests/test_has.R
+++ b/tests/test_has.R
@@ -5,32 +5,31 @@ data(sample_matrix, package = "xts")
 d <- as.xts(sample_matrix)
 simple.colnames <- c("Open", "High", "Low", "Close")
 
-
-#has.OHLC will test has.op, has,cl, etc
+#has.OHLC will test underlying has.op, hasCl, etc
 colnames(d) <- simple.colnames
-expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d), rep(TRUE,4))
 expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
 
 colnames(d) <- paste("OPEN", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d), rep(TRUE,4))
 expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
 
 colnames(d) <- paste("HIGH", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d), rep(TRUE,4))
 expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
 
 colnames(d) <- paste("LOW", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d), rep(TRUE,4))
 expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
 
 colnames(d) <- paste("ILOW", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d), rep(TRUE,4))
 expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
 
 colnames(d) <- paste("LOW.W", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d), rep(TRUE,4))
 expect_equal(has.OHLC(d, which = T), c(1,2,3,4))
 
 colnames(d) <- paste("My.LOW", simple.colnames, sep = ".")
-expect_equal(has.OHLC(d), TRUE)
+expect_equal(has.OHLC(d), rep(TRUE,4))
 expect_equal(has.OHLC(d, which = T), c(1,2,3,4))

--- a/tests/test_has.R
+++ b/tests/test_has.R
@@ -36,6 +36,10 @@ colnames(stock) <- paste("My.LOW", simple.colnames, sep = ".")
 expect_true(all(has.OHLC(stock)))
 expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
 
+colnames(stock) <- paste("VLOWY", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
+
 expect_true(has.Op(stock))
 expect_true(has.Hi(stock))
 expect_true(has.Lo(stock))

--- a/tests/test_has.R
+++ b/tests/test_has.R
@@ -7,44 +7,14 @@ stock$Volume <- stock$Close
 stock$Adjusted <- stock$Close
 simple.colnames <- c("Open", "High", "Low", "Close", "Volume", "Adjusted")
 
-#has.OHLC will test underlying has.op, hasCl, etc
-colnames(stock) <- simple.colnames
-expect_true(all(has.OHLC(stock)))
-expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
-
-colnames(stock) <- paste("OPEN", simple.colnames, sep = ".")
-expect_true(all(has.OHLC(stock)))
-expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
-
-colnames(stock) <- paste("HIGH", simple.colnames, sep = ".")
-expect_true(all(has.OHLC(stock)))
-expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
-
-colnames(stock) <- paste("LOW", simple.colnames, sep = ".")
-expect_true(all(has.OHLC(stock)))
-expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
-
-colnames(stock) <- paste("ILOW", simple.colnames, sep = ".")
-expect_true(all(has.OHLC(stock)))
-expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
-
-colnames(stock) <- paste("LOW.W", simple.colnames, sep = ".")
-expect_true(all(has.OHLC(stock)))
-expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
-
-colnames(stock) <- paste("My.LOW", simple.colnames, sep = ".")
-expect_true(all(has.OHLC(stock)))
-expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
-
-colnames(stock) <- paste("VLOWY", simple.colnames, sep = ".")
-expect_true(all(has.OHLCV(stock)))
-expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
-
+# basic functionality
+colnames(stock) <- paste("MSFT", simple.colnames, sep = ".")
 expect_true(has.Op(stock))
 expect_true(has.Hi(stock))
 expect_true(has.Lo(stock))
 expect_true(has.Cl(stock))
 expect_true(has.Vo(stock))
+expect_true(has.Ad(stock))
 expect_true(is.HLC(stock))
 expect_true(all(has.HLC(stock)))
 expect_true(is.OHLC(stock))
@@ -58,69 +28,67 @@ expect_equal(has.Hi(stock, which = TRUE), 2)
 expect_equal(has.Lo(stock, which = TRUE), 3)
 expect_equal(has.Cl(stock, which = TRUE), 4)
 expect_equal(has.Vo(stock, which = TRUE), 5)
+expect_equal(has.Ad(stock, which = TRUE), 6)
 expect_equal(has.HLC(stock, which = TRUE), c(2,3,4))
 expect_equal(has.OHLC(stock, which = TRUE), c(1,2,3,4))
 expect_equal(has.OHLCV(stock, which = TRUE), c(1,2,3,4,5))
 
-# Test return correct OHLC column(s).
-expect_identical(colnames(Op(stock)), cols[1])
-expect_identical(colnames(Hi(stock)), cols[2])
-expect_identical(colnames(Lo(stock)), cols[3])
-expect_identical(colnames(Cl(stock)), cols[4])
-expect_identical(colnames(HLC(stock)), cols[c(2,3,4)])
-expect_identical(colnames(OHLC(stock)), cols[c(1,2,3,4)])
-expect_identical(colnames(OHLCV(stock)), cols[c(1,2,3,4,5)])
+#has.OHLC will test underlying has.Op, has.Cl, etc. It will NOT test has.Ad
+colnames(stock) <- simple.colnames
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
 
-# Test sample matrix regression
-data(sample_matrix, package = "xts")
-sample <- as.xts(sample_matrix)
-expect_equal(has.Op(sample, which = TRUE), 1)
-expect_equal(has.Hi(sample, which = TRUE), 2)
-expect_equal(has.Lo(sample, which = TRUE), 3)
-expect_equal(has.Cl(sample, which = TRUE), 4)
-expect_identical(colnames(Op(sample)), "Open")
-expect_identical(colnames(Hi(sample)), "High")
-expect_identical(colnames(Lo(sample)), "Low")
-expect_identical(colnames(Cl(sample)), "Close")
+colnames(stock) <- paste("OPEN", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
 
-# Test "Open" columns with symbol "OPEN".
-colnames(stock) <- gsub("MSFT", "OPEN", cols)
-expect_true(has.Op(stock))
-expect_equal(has.Op(stock, which = TRUE), 1)
-expect_identical(colnames(Op(stock)), colnames(stock)[1])
+colnames(stock) <- paste("HIGH", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
 
-# Test "High" columns with symbol "HIGH".
-colnames(stock) <- gsub("MSFT", "HIGH", cols)
-expect_true(has.Hi(stock))
-expect_equal(has.Hi(stock, which = TRUE), 2)
-expect_identical(colnames(Hi(stock)), colnames(stock)[2])
+colnames(stock) <- paste("LOW", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
 
-# Test "Low" columns with symbol "LOW".
-colnames(stock) <- gsub("MSFT", "LOW", cols)
-expect_true(has.Lo(stock))
-expect_equal(has.Lo(stock, which = TRUE), 3)
-expect_identical(colnames(Lo(stock)), colnames(stock)[3])
+colnames(stock) <- paste("CLOSE", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
 
-# Test "Close" columns with symbol "CLOSE".
-colnames(stock) <- gsub("MSFT", "CLOSE", cols)
-expect_true(has.Cl(stock))
-expect_equal(has.Cl(stock, which = TRUE), 4)
-expect_identical(colnames(Cl(stock)), colnames(stock)[4])
+colnames(stock) <- paste("VOLUME", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
 
-# Test "Volume" columns with symbol "VOLUME".
-colnames(stock) <- gsub("MSFT", "VOLUME", cols)
-expect_true(has.Vo(stock))
-expect_equal(has.Vo(stock, which = TRUE), 5)
-expect_identical(colnames(Vo(stock)), colnames(stock)[5])
+colnames(stock) <- paste("ADJUSTED", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
 
-# Test "Adjusted" columns with symbol "ADJUSTED".
-colnames(stock) <- gsub("MSFT", "ADJUSTED", cols)
-expect_true(has.Ad(stock))
-expect_equal(has.Ad(stock, which = TRUE), 6)
-expect_identical(colnames(Ad(stock)), colnames(stock)[6])
+colnames(stock) <- paste("ILOW", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
+
+colnames(stock) <- paste("LOW.W", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
+
+colnames(stock) <- paste("LOW_A", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
+
+colnames(stock) <- paste("^LOW", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
+
+colnames(stock) <- paste("My.LOW", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
+
+colnames(stock) <- paste("VLOWY", simple.colnames, sep = ".")
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
 
 # low in colname returned by function TTR::stoch()
-colnames(stock) <- simple.colnames
+colnames(stock) <- paste("LOW", simple.colnames, sep = ".")
 stock$slowD <- stock[,4]
-expect_true(all(has.OHLC(stock)))
-expect_equal(has.OHLC(stock, which = T), c(1,2,3,4))
+expect_true(all(has.OHLCV(stock)))
+expect_equal(has.OHLCV(stock, which = T), c(1,2,3,4,5))
+stock$slowD <- NULL


### PR DESCRIPTION
added a fallback refined search using "." prefix if multiple columns found. possible this should be the primary path
modified "getters" to use has(which = TRUE) to reuse search code

fixes #305
