### PR TITLE
Use gate for code for use of '<'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -120,7 +120,9 @@
     The example below will create an object named `IXIC` but the value of
     `sym` will be "^IXIC".
 
-        sym <- getSymbols("^IXIC")
+    ```r
+    sym <- getSymbols("^IXIC")
+    ```
 
     That means `x <- get(sym)` will not work because an object named `^IXIC`
     doesn't exist.


### PR DESCRIPTION
Our parser complained that "`<` is unclosed" -- it may be implementation-dependent whether 2x the 4-space indentation has the intended effect. Using syntax-indicated gates is probably best practice these days anyway...