### PR TITLE
Explicitly disable fancy quotes in test-Defaults

### DIFF
--- a/tests/test-Defaults.R
+++ b/tests/test-Defaults.R
@@ -4,6 +4,7 @@
 # all tests in an environment that's different from the Global Environment.
 
 library(quantmod)
+options(useFancyQuotes = FALSE)
 
 api.key <- "abc"
 src <- "xyz"


### PR DESCRIPTION
As is in our test environment, we get a failure:

```
Error: identical(sQuote(api.key), default.key) is not TRUE
```

I can add more context if requested. I'm not sure why our environment differs from e.g. CRAN here, but it seems fine to be explicit (and I hate fancy quotes for testing anyway).